### PR TITLE
Refactor database operations

### DIFF
--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -201,16 +201,14 @@ impl FediProtoSyncLoop {
             }
         }
 
-        let cached_files_to_delete = crate::schema::cached_files::table
-            .select(crate::db::models::CachedFile::as_select())
-            .load(&mut self.db_connection)?;
+        let cached_files_to_delete = db::operations::get_cached_file_records(&mut self.db_connection)?;
 
         if cached_files_to_delete.len() > 0 {
             tracing::info!("Deleting cached files during sync...");
 
             for cached_file in cached_files_to_delete {
                 tracing::info!("Deleting cached file '{}'.", cached_file.file_path);
-                crate::db::models::remove_cached_file(&cached_file, &mut self.db_connection).await?;
+                cached_file.remove_file(&mut self.db_connection).await?;
             }
         }
 

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -1,6 +1,6 @@
 use atprotolib_rs::types::app_bsky;
 use diesel::{
-    Connection, ExpressionMethods, OptionalExtension, PgConnection, QueryDsl, RunQueryDsl, SelectableHelper, SqliteConnection
+    Connection, PgConnection, QueryDsl, RunQueryDsl, SelectableHelper, SqliteConnection
 };
 
 use crate::{bsky, mastodon::MastodonApiExtensions, FediProtoSyncEnvVars, db::{self, models}};

--- a/fediproto-sync/src/db/mod.rs
+++ b/fediproto-sync/src/db/mod.rs
@@ -1,5 +1,6 @@
 pub mod core;
 pub mod models;
+pub mod operations;
 pub mod type_impls;
 
 use diesel::{

--- a/fediproto-sync/src/db/models.rs
+++ b/fediproto-sync/src/db/models.rs
@@ -124,7 +124,7 @@ impl NewMastodonPost {
 #[derive(Queryable, Selectable, Clone, PartialEq, Debug)]
 #[allow(dead_code)]
 #[diesel(table_name = crate::schema::synced_posts)]
-pub struct SyncedPost {
+pub struct SyncedPostBlueSkyData {
     /// A unique identifier for the synced post in the database.
     pub id: crate::db::type_impls::UuidProxy,
 
@@ -141,7 +141,7 @@ pub struct SyncedPost {
 /// Represents a new synced post to insert into the `synced_posts` table.
 #[derive(Insertable)]
 #[diesel(table_name = crate::schema::synced_posts)]
-pub struct NewSyncedPost {
+pub struct NewSyncedPostBlueSkyData {
     /// A unique identifier for the synced post in the database.
     pub id: crate::db::type_impls::UuidProxy,
 
@@ -155,8 +155,8 @@ pub struct NewSyncedPost {
     pub bsky_post_uri: String
 }
 
-impl NewSyncedPost {
-    /// Create a new instance of the `NewSyncedPost` struct.
+impl NewSyncedPostBlueSkyData {
+    /// Create a new instance of the `NewSyncedPostBlueSkyData` struct.
     ///
     /// ## Arguments
     ///

--- a/fediproto-sync/src/db/operations.rs
+++ b/fediproto-sync/src/db/operations.rs
@@ -1,0 +1,121 @@
+use diesel::prelude::*;
+
+/// Get a synced Mastodon post by its ID from the database.
+/// 
+/// ## Arguments
+/// 
+/// * `db_connection` - The database connection to use.
+/// * `mastodon_post_id` - The Mastodon post ID to get.
+pub fn get_synced_mastodon_post_by_id(
+    db_connection: &mut crate::db::AnyConnection,
+    mastodon_post_id: &str
+) -> Result<crate::db::models::MastodonPost, crate::error::Error> {
+    let post = crate::schema::mastodon_posts::table
+        .filter(crate::schema::mastodon_posts::post_id.eq(mastodon_post_id))
+        .first::<crate::db::models::MastodonPost>(db_connection)
+        .map_err(|e| {
+            crate::error::Error::with_source(
+                "Failed to get Mastodon post by ID.",
+                crate::error::ErrorKind::DatabaseQueryError,
+                Box::new(e)
+            )
+        })?;
+
+    Ok(post)
+}
+
+/// Get the last synced Mastodon post ID from the database.
+///
+/// ## Arguments
+///
+/// * `db_connection` - The database connection to use.
+pub fn get_last_synced_mastodon_post_id(
+    db_connection: &mut crate::db::AnyConnection
+) -> Result<Option<String>, crate::error::Error> {
+    let last_synced_post_id = crate::schema::mastodon_posts::table
+        .order(crate::schema::mastodon_posts::created_at.desc())
+        .select(crate::schema::mastodon_posts::post_id)
+        .first::<String>(db_connection)
+        .optional()
+        .map_err(|e| {
+            crate::error::Error::with_source(
+                "Failed to get the last synced Mastodon post ID.",
+                crate::error::ErrorKind::DatabaseQueryError,
+                Box::new(e)
+            )
+        })?;
+
+    Ok(last_synced_post_id)
+}
+
+/// Insert a new synced Mastodon post into the database.
+///
+/// ## Arguments
+///
+/// * `db_connection` - The database connection to use.
+/// * `new_post` - The new post to insert.
+pub fn insert_new_synced_mastodon_post(
+    db_connection: &mut crate::db::AnyConnection,
+    new_post: &crate::db::models::NewMastodonPost
+) -> Result<(), crate::error::Error> {
+    diesel::insert_into(crate::schema::mastodon_posts::table)
+        .values(new_post)
+        .execute(db_connection)
+        .map_err(|e| {
+            crate::error::Error::with_source(
+                "Failed to insert new synced Mastodon post.",
+                crate::error::ErrorKind::DatabaseInsertError,
+                Box::new(e)
+            )
+        })?;
+
+    Ok(())
+}
+
+/// Get BlueSky data of a synced Mastodon post by its Mastodon post ID.
+/// 
+/// ## Arguments
+/// 
+/// * `db_connection` - The database connection to use.
+/// * `mastodon_post_id` - The Mastodon post ID to get.
+pub fn get_bluesky_data_by_mastodon_post_id(
+    db_connection: &mut crate::db::AnyConnection,
+    mastodon_post_id: &str
+) -> Result<crate::db::models::SyncedPostBlueSkyData, crate::error::Error> {
+    let synced_post = crate::schema::synced_posts::table
+        .filter(crate::schema::synced_posts::mastodon_post_id.eq(mastodon_post_id))
+        .first::<crate::db::models::SyncedPostBlueSkyData>(db_connection)
+        .map_err(|e| {
+            crate::error::Error::with_source(
+                "Failed to get synced post by post ID.",
+                crate::error::ErrorKind::DatabaseQueryError,
+                Box::new(e)
+            )
+        })?;
+
+    Ok(synced_post)
+}
+
+/// Insert new BlueSky data for a synced Mastodon post into the database.
+/// 
+/// ## Arguments
+/// 
+/// * `db_connection` - The database connection to use.
+/// * `synced_post_data` - The new synced post to insert.
+pub fn insert_new_bluesky_data_for_synced_mastodon_post(
+    db_connection: &mut crate::db::AnyConnection,
+    synced_post_data: &crate::db::models::NewSyncedPostBlueSkyData
+) -> Result<(), crate::error::Error> {
+    diesel::insert_into(crate::schema::synced_posts::table)
+        .values(synced_post_data)
+        .execute(db_connection)
+        .map_err(|e| {
+            crate::error::Error::with_source(
+                "Failed to insert new synced post.",
+                crate::error::ErrorKind::DatabaseInsertError,
+                Box::new(e)
+            )
+        })?;
+
+    Ok(())
+}

--- a/fediproto-sync/src/db/operations.rs
+++ b/fediproto-sync/src/db/operations.rs
@@ -119,3 +119,67 @@ pub fn insert_new_bluesky_data_for_synced_mastodon_post(
 
     Ok(())
 }
+
+/// Get records of cached files from the database.
+/// 
+/// ## Arguments
+/// 
+/// * `db_connection` - The database connection to use.
+pub fn get_cached_file_records(
+    db_connection: &mut crate::db::AnyConnection
+) -> Result<Vec<crate::db::models::CachedFile>, crate::error::Error> {
+    let cached_files = crate::schema::cached_files::table
+            .select(crate::db::models::CachedFile::as_select())
+            .load(db_connection)
+            .map_err(|e| crate::error::Error::with_source(
+                "Failed to get cached files.",
+                crate::error::ErrorKind::DatabaseQueryError,
+                Box::new(e)
+            ))?;
+
+    Ok(cached_files)
+}
+
+/// Insert a new cached file record into the database.
+/// 
+/// ## Arguments
+/// 
+/// * `db_connection` - The database connection to use.
+/// * `new_cached_file` - The new cached file record to insert.
+pub fn insert_cached_file_record(
+    db_connection: &mut crate::db::AnyConnection,
+    new_cached_file: &crate::db::models::NewCachedFile
+) -> Result<(), crate::error::Error> {
+    diesel::insert_into(crate::schema::cached_files::table)
+        .values(new_cached_file)
+        .execute(db_connection)
+        .map_err(|e| crate::error::Error::with_source(
+            "Failed to insert new cached file.",
+            crate::error::ErrorKind::DatabaseInsertError,
+            Box::new(e)
+        ))?;
+
+    Ok(())
+}
+
+/// Delete a cached file record from the database.
+/// 
+/// ## Arguments
+/// 
+/// * `db_connection` - The database connection to use.
+/// * `cached_file` - The cached file record to delete.
+pub fn delete_cached_file_record(
+    db_connection: &mut crate::db::AnyConnection,
+    cached_file: &crate::db::models::CachedFile
+) -> Result<(), crate::error::Error> {
+    diesel::delete(crate::schema::cached_files::table)
+        .filter(crate::schema::cached_files::id.eq(cached_file.id))
+        .execute(db_connection)
+        .map_err(|e| crate::error::Error::with_source(
+            "Failed to delete cached file record.",
+            crate::error::ErrorKind::DatabaseDeleteError,
+            Box::new(e)
+        ))?;
+
+    Ok(())
+}

--- a/fediproto-sync/src/error.rs
+++ b/fediproto-sync/src/error.rs
@@ -92,6 +92,9 @@ pub enum ErrorKind {
     /// An error occurred while trying to insert a new record into the database.
     DatabaseInsertError,
 
+    /// An error occurred while trying to delete a database record.
+    DatabaseDeleteError,
+
     /// An error occurred while creating a HTTP client.
     HttpClientCreationError,
 

--- a/fediproto-sync/src/error.rs
+++ b/fediproto-sync/src/error.rs
@@ -86,6 +86,12 @@ pub enum ErrorKind {
     /// An invalid database type was specified.
     InvalidDatabaseType,
 
+    /// An error occurred while querying the database.
+    DatabaseQueryError,
+
+    /// An error occurred while trying to insert a new record into the database.
+    DatabaseInsertError,
+
     /// An error occurred while creating a HTTP client.
     HttpClientCreationError,
 


### PR DESCRIPTION
## Description

* Common database operations have been refactored into their own module.
* Renamed `SyncedPost` to `SyncedPostBlueSkyData`.
    * Should be less ambiguous now.
    * The `synced_posts` table will be renamed in a later PR.

### Related issues

- None

### Stack

<!-- branch-stack -->
