### PR TITLE
Renamed synced_posts database table

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -98,7 +98,7 @@
       "options": {
         "cwd": "${workspaceFolder}",
         "env": {
-          "FEDIPROTO_SYNC_ENVIRONMENT": "Development"
+          "FEDIPROTO_SYNC_ENVIRONMENT": "Development_${input:dbType}",
         }
       },
       "presentation": {

--- a/fediproto-sync/migrations/postgres/2024-12-09-173219_rename_synced_posts/down.sql
+++ b/fediproto-sync/migrations/postgres/2024-12-09-173219_rename_synced_posts/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE "synced_posts_bluesky_data" RENAME TO "synced_posts";

--- a/fediproto-sync/migrations/postgres/2024-12-09-173219_rename_synced_posts/up.sql
+++ b/fediproto-sync/migrations/postgres/2024-12-09-173219_rename_synced_posts/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+
+ALTER TABLE "synced_posts" RENAME TO "synced_posts_bluesky_data";

--- a/fediproto-sync/migrations/sqlite/2024-12-09-173219_rename_synced_posts/down.sql
+++ b/fediproto-sync/migrations/sqlite/2024-12-09-173219_rename_synced_posts/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE `synced_posts_bluesky_data` RENAME TO `synced_posts`;

--- a/fediproto-sync/migrations/sqlite/2024-12-09-173219_rename_synced_posts/up.sql
+++ b/fediproto-sync/migrations/sqlite/2024-12-09-173219_rename_synced_posts/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+
+ALTER TABLE `synced_posts` RENAME TO `synced_posts_bluesky_data`;

--- a/fediproto-sync/src/db/models.rs
+++ b/fediproto-sync/src/db/models.rs
@@ -116,10 +116,10 @@ impl NewMastodonPost {
     }
 }
 
-/// Represents a synced post in the `synced_posts` table.
+/// Represents a synced post in the `synced_posts_bluesky_data` table.
 #[derive(Queryable, Selectable, Clone, PartialEq, Debug)]
 #[allow(dead_code)]
-#[diesel(table_name = crate::schema::synced_posts)]
+#[diesel(table_name = crate::schema::synced_posts_bluesky_data)]
 pub struct SyncedPostBlueSkyData {
     /// A unique identifier for the synced post in the database.
     pub id: crate::db::type_impls::UuidProxy,
@@ -134,9 +134,9 @@ pub struct SyncedPostBlueSkyData {
     pub bsky_post_uri: String
 }
 
-/// Represents a new synced post to insert into the `synced_posts` table.
+/// Represents a new synced post to insert into the `synced_posts_bluesky_data` table.
 #[derive(Insertable)]
-#[diesel(table_name = crate::schema::synced_posts)]
+#[diesel(table_name = crate::schema::synced_posts_bluesky_data)]
 pub struct NewSyncedPostBlueSkyData {
     /// A unique identifier for the synced post in the database.
     pub id: crate::db::type_impls::UuidProxy,

--- a/fediproto-sync/src/db/operations.rs
+++ b/fediproto-sync/src/db/operations.rs
@@ -82,8 +82,8 @@ pub fn get_bluesky_data_by_mastodon_post_id(
     db_connection: &mut crate::db::AnyConnection,
     mastodon_post_id: &str
 ) -> Result<crate::db::models::SyncedPostBlueSkyData, crate::error::Error> {
-    let synced_post = crate::schema::synced_posts::table
-        .filter(crate::schema::synced_posts::mastodon_post_id.eq(mastodon_post_id))
+    let synced_post = crate::schema::synced_posts_bluesky_data::table
+        .filter(crate::schema::synced_posts_bluesky_data::mastodon_post_id.eq(mastodon_post_id))
         .first::<crate::db::models::SyncedPostBlueSkyData>(db_connection)
         .map_err(|e| {
             crate::error::Error::with_source(
@@ -106,7 +106,7 @@ pub fn insert_new_bluesky_data_for_synced_mastodon_post(
     db_connection: &mut crate::db::AnyConnection,
     synced_post_data: &crate::db::models::NewSyncedPostBlueSkyData
 ) -> Result<(), crate::error::Error> {
-    diesel::insert_into(crate::schema::synced_posts::table)
+    diesel::insert_into(crate::schema::synced_posts_bluesky_data::table)
         .values(synced_post_data)
         .execute(db_connection)
         .map_err(|e| {

--- a/fediproto-sync/src/schema.rs
+++ b/fediproto-sync/src/schema.rs
@@ -14,7 +14,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    synced_posts (id) {
+    synced_posts_bluesky_data (id) {
         id -> crate::db::type_impls::MultiBackendUuid,
         mastodon_post_id -> VarChar,
         bsky_post_cid -> VarChar,

--- a/fediproto-sync/src/schema_postgres.rs
+++ b/fediproto-sync/src/schema_postgres.rs
@@ -14,7 +14,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    synced_posts (id) {
+    synced_posts_bluesky_data (id) {
         id -> Uuid,
         mastodon_post_id -> VarChar,
         bsky_post_cid -> VarChar,

--- a/fediproto-sync/src/schema_sqlite.rs
+++ b/fediproto-sync/src/schema_sqlite.rs
@@ -14,7 +14,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    synced_posts (id) {
+    synced_posts_bluesky_data (id) {
         id -> Text,
         mastodon_post_id -> Text,
         bsky_post_cid -> Text,


### PR DESCRIPTION
## Description

Trying to reduce the ambiguity of the `synced_posts` table, so I've renamed it to `synced_posts_bluesky_data`. Database migration files are included for both PostgreSQL and SQLite and will be applied when FediProto Sync runs.

### Related issues

- None

### Stack

<!-- branch-stack -->
