### PR TITLE
Allow pinned posts when fetching Mastodon statuses

### DIFF
--- a/fediproto-sync/src/mastodon.rs
+++ b/fediproto-sync/src/mastodon.rs
@@ -30,7 +30,7 @@ impl MastodonApiExtensions for Box<dyn megalodon::Megalodon + Send + Sync> {
             limit: limit_value,
             max_id: None,
             since_id: last_post_id,
-            pinned: Some(false),
+            pinned: Some(true),
             exclude_replies: Some(true),
             exclude_reblogs: Some(true),
             only_media: Some(false),


### PR DESCRIPTION
## Description

Pinned posts will now be allowed to be retrieved. If a post is pinned before FediProto Sync is able to sync, it'll skip over that post entirely.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#9 :point\_left:
