### PR TITLE
Replace openssl crate with boring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +139,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "boring"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f5aac023c3ba13725de1604aff621a9dbf9a4f3af1ea6fb712bca91ad729a8e"
+dependencies = [
+ "bitflags 2.6.0",
+ "boring-sys",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+]
+
+[[package]]
+name = "boring-sys"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebabcc15924f3244f244cfb1dfe43c0b28236ea8c1f71dc8e5a146eae0342d79"
+dependencies = [
+ "autocfg",
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -151,6 +196,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +229,26 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -453,6 +527,7 @@ name = "fediproto-sync"
 version = "0.1.0"
 dependencies = [
  "atprotolib-rs",
+ "boring",
  "bytes",
  "chrono",
  "diesel",
@@ -462,7 +537,6 @@ dependencies = [
  "git-version",
  "megalodon",
  "oauth2",
- "openssl",
  "rand",
  "reqwest 0.12.9",
  "serde",
@@ -491,18 +565,30 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
+ "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "foreign-types-macros"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -511,6 +597,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -641,6 +743,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1046,6 +1154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1189,16 @@ name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "libloading"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1151,7 +1278,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.4",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -1205,6 +1332,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1362,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1291,21 +1434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
-name = "openssl"
-version = "0.10.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,18 +1449,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "overload"
@@ -1507,7 +1623,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.19",
  "socket2",
  "thiserror 2.0.4",
@@ -1525,7 +1641,7 @@ dependencies = [
  "getrandom",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.0",
  "rustls 0.23.19",
  "rustls-pki-types",
  "slab",
@@ -1747,6 +1863,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN chmod +x ./docker-build/build.sh \
 FROM --platform=${TARGETARCH:-$BUILDPLATFORM} docker.io/library/debian:bullseye-slim
 
 RUN apt-get update \
-    && apt-get install -y libsqlite3-0 libpq5 openssl ca-certificates \
+    && apt-get install -y libsqlite3-0 libpq5 ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -10,7 +10,7 @@ case "${TARGETPLATFORM}" in
 
         dpkg --add-architecture amd64
         apt-get update
-        apt-get install -y libpq-dev:amd64 libpq5:amd64 libsqlite3-dev:amd64 libsqlite3-0:amd64 libssl-dev:amd64 openssl:amd64
+        apt-get install -y libpq-dev:amd64 libpq5:amd64 libsqlite3-dev:amd64 libsqlite3-0:amd64
         apt-get clean
         rm -rf /var/lib/apt/lists/*
         ;;
@@ -22,7 +22,7 @@ case "${TARGETPLATFORM}" in
 
         dpkg --add-architecture arm64
         apt-get update
-        apt-get install -y libpq-dev:arm64 libpq5:arm64 libsqlite3-dev:arm64 libsqlite3-0:arm64 libssl-dev:arm64 openssl:arm64
+        apt-get install -y libpq-dev:arm64 libpq5:arm64 libsqlite3-dev:arm64 libsqlite3-0:arm64
         apt-get clean
         rm -rf /var/lib/apt/lists/*
         ;;

--- a/fediproto-sync/Cargo.toml
+++ b/fediproto-sync/Cargo.toml
@@ -41,8 +41,8 @@ rand = "0.8.5"
 uuid = { version = "1.11.0", features = ["v4", "v7", "fast-rng"] }
 oauth2 = "4.4.2"
 url = "2.5.4"
-openssl = "0.10.68"
 bytes = "1.9.0"
+boring = "4.13.0"
 
 [build-dependencies]
 git-version = "0.3.9"

--- a/fediproto-sync/src/config.rs
+++ b/fediproto-sync/src/config.rs
@@ -14,10 +14,10 @@ pub struct FediProtoSyncEnvVars {
     pub database_url: String,
 
     /// The encryption key to use for token encryption.
-    pub token_encryption_private_key: Option<openssl::rsa::Rsa<openssl::pkey::Private>>,
+    pub token_encryption_private_key: Option<boring::rsa::Rsa<boring::pkey::Private>>,
 
     /// The encryption IV to use for token encryption.
-    pub token_encryption_public_key: Option<openssl::rsa::Rsa<openssl::pkey::Public>>,
+    pub token_encryption_public_key: Option<boring::rsa::Rsa<boring::pkey::Public>>,
 
     /// User-Agent string to use for HTTP requests.
     pub user_agent: String,
@@ -107,7 +107,7 @@ impl FediProtoSyncEnvVars {
                         Box::new(e)
                     )
                 })?;
-                let private_key = openssl::base64::decode_block(&private_key).map_err(|e| {
+                let private_key = boring::base64::decode_block(&private_key).map_err(|e| {
                     crate::error::Error::with_source(
                         "Failed to decode the TOKEN_ENCRYPTION_PRIVATE_KEY environment variable.",
                         crate::error::ErrorKind::EnvironmentVariableError,
@@ -115,7 +115,7 @@ impl FediProtoSyncEnvVars {
                     )
                 })?;
                 let private_key =
-                    openssl::rsa::Rsa::private_key_from_pem(&private_key).map_err(|e| {
+                    boring::rsa::Rsa::private_key_from_pem(&private_key).map_err(|e| {
                         crate::error::Error::with_source(
                             "Failed to decode TOKEN_ENCRYPTION_PRIVATE_KEY environment variable.",
                             crate::error::ErrorKind::EnvironmentVariableError,
@@ -139,7 +139,7 @@ impl FediProtoSyncEnvVars {
                         Box::new(e)
                     )
                 })?;
-                let public_key = openssl::base64::decode_block(&public_key).map_err(|e| {
+                let public_key = boring::base64::decode_block(&public_key).map_err(|e| {
                     crate::error::Error::with_source(
                         "Failed to decode the TOKEN_ENCRYPTION_PUBLIC_KEY environment variable.",
                         crate::error::ErrorKind::EnvironmentVariableError,
@@ -147,7 +147,7 @@ impl FediProtoSyncEnvVars {
                     )
                 })?;
                 let public_key =
-                    openssl::rsa::Rsa::public_key_from_pem(&public_key).map_err(|e| {
+                    boring::rsa::Rsa::public_key_from_pem(&public_key).map_err(|e| {
                         crate::error::Error::with_source(
                             "Failed to decode TOKEN_ENCRYPTION_PUBLIC_KEY environment variable.",
                             crate::error::ErrorKind::EnvironmentVariableError,

--- a/fediproto-sync/src/crypto.rs
+++ b/fediproto-sync/src/crypto.rs
@@ -5,19 +5,19 @@
 /// 
 /// * `public_key` - The public key to use for encryption.
 pub fn encrypt_string(
-    public_key: &openssl::rsa::Rsa<openssl::pkey::Public>,
+    public_key: &boring::rsa::Rsa<boring::pkey::Public>,
     input_string: &str
 ) -> Result<String, crate::error::Error> {
     let mut encrypted_string = vec![0; public_key.size() as usize];
 
-    public_key.public_encrypt(input_string.as_bytes(), &mut encrypted_string, openssl::rsa::Padding::PKCS1)
+    public_key.public_encrypt(input_string.as_bytes(), &mut encrypted_string, boring::rsa::Padding::PKCS1)
         .map_err(|e| crate::error::Error::with_source(
             "Failed to encrypt string",
             crate::error::ErrorKind::EncryptionError,
             Box::new(e)
         ))?;
 
-    let encoded_string = openssl::base64::encode_block(&encrypted_string);
+    let encoded_string = boring::base64::encode_block(&encrypted_string);
 
     Ok(encoded_string)
 }
@@ -28,19 +28,19 @@ pub fn encrypt_string(
 /// 
 /// * `private_key` - The private key to use for decryption.
 pub fn decrypt_string(
-    private_key: &openssl::rsa::Rsa<openssl::pkey::Private>,
+    private_key: &boring::rsa::Rsa<boring::pkey::Private>,
     input_string: &str
 ) -> Result<String, crate::error::Error> {
     let mut decrypted_string = vec![0; private_key.size() as usize];
 
-    let encrypted_string = openssl::base64::decode_block(input_string)
+    let encrypted_string = boring::base64::decode_block(input_string)
         .map_err(|e| crate::error::Error::with_source(
             "Failed to decode base64 string",
             crate::error::ErrorKind::DecryptionError,
             Box::new(e)
         ))?;
 
-    let decrypted_length = private_key.private_decrypt(&encrypted_string, &mut decrypted_string, openssl::rsa::Padding::PKCS1)
+    let decrypted_length = private_key.private_decrypt(&encrypted_string, &mut decrypted_string, boring::rsa::Padding::PKCS1)
         .map_err(|e| crate::error::Error::with_source(
             "Failed to decrypt string",
             crate::error::ErrorKind::DecryptionError,

--- a/fediproto-sync/src/db/models.rs
+++ b/fediproto-sync/src/db/models.rs
@@ -277,7 +277,7 @@ pub trait CachedServiceTokenDecrypt {
     /// * `encryption_private_key` - The private key to use for decryption.
      fn decrypt_access_token(
         &self,
-        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
+        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
     ) -> Result<String, crate::error::Error>;
 
     /// Decrypt the refresh token.
@@ -292,7 +292,7 @@ pub trait CachedServiceTokenDecrypt {
     #[allow(dead_code)]
      fn decrypt_refresh_token(
         &self,
-        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
+        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
     ) -> Result<Option<String>, crate::error::Error>;
 }
 
@@ -304,7 +304,7 @@ impl CachedServiceTokenDecrypt for CachedServiceToken {
     /// * `encryption_private_key` - The private key to use for decryption.
      fn decrypt_access_token(
         &self,
-        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
+        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
     ) -> Result<String, crate::error::Error> {
         let decrypted_access_token = crate::crypto::decrypt_string(encryption_private_key, &self.access_token)?;
 
@@ -323,7 +323,7 @@ impl CachedServiceTokenDecrypt for CachedServiceToken {
     #[allow(dead_code)]
      fn decrypt_refresh_token(
         &self,
-        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
+        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
     ) -> Result<Option<String>, crate::error::Error> {
         let decrypted_refresh_token = match &self.refresh_token {
             Some(refresh_token) => {
@@ -374,7 +374,7 @@ impl NewCachedServiceToken {
     /// * `expires_in` - The time in seconds until the access token expires, if any.
     /// * `scopes` - The scopes the access token has, if any.
     pub fn new(
-        encryption_public_key: &openssl::rsa::Rsa<openssl::pkey::Public>,
+        encryption_public_key: &boring::rsa::Rsa<boring::pkey::Public>,
         service_name: &str,
         access_token: &str,
         refresh_token: Option<String>,


### PR DESCRIPTION
## Description

Replacing `openssl` with `boring`, since BoringSSL is easier to cross-compile than OpenSSL.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#15 :point\_left:
