### PR TITLE
Revert back to OpenSSL and fix cross-compilation

### DIFF
--- a/.github/workflows/create-container-image.yml
+++ b/.github/workflows/create-container-image.yml
@@ -19,21 +19,9 @@ permissions:
 jobs:
   create-image:
     name: Create container image
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'fediproto-selfhosted-arm64' || 'ubuntu-latest' }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - "linux/amd64"
-          - "linux/arm64"
+    runs-on: ubuntu-latest
 
     steps:
-      - name: Prepare
-        run: |
-          platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
-
       - name: "Checkout"
         uses: actions/checkout@v4
         with:
@@ -52,53 +40,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: "Build container image"
-        id: build
-        uses: docker/build-push-action@v6
-        with:
-          context: ./
-          file: ./Dockerfile
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=ghcr.io/smalls1652/fediproto-sync,push-by-digest=true,name-canonical=true,push=true
-
-      - name: Export digest
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digests-${{ env.PLATFORM_PAIR }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-  
-  merge:
-    name: Merge digests and push manifest
-    runs-on: ubuntu-latest
-    needs:
-      - create-image
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log into container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: "Generate Docker metadata"
         id: meta
         uses: docker/metadata-action@v5
@@ -111,12 +52,12 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf 'ghcr.io/smalls1652/fediproto-sync@sha256:%s ' *)
-
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ghcr.io/smalls1652/fediproto-sync:${{ steps.meta.outputs.version }}
+      - name: "Build and push Docker image"
+        uses: docker/build-push-action@v6
+        with:
+          context: ./
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' && true || github.event.inputs.push }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,24 +103,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,33 +121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "boring"
-version = "4.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5aac023c3ba13725de1604aff621a9dbf9a4f3af1ea6fb712bca91ad729a8e"
-dependencies = [
- "bitflags 2.6.0",
- "boring-sys",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
-]
-
-[[package]]
-name = "boring-sys"
-version = "4.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebabcc15924f3244f244cfb1dfe43c0b28236ea8c1f71dc8e5a146eae0342d79"
-dependencies = [
- "autocfg",
- "bindgen",
- "cmake",
- "fs_extra",
- "fslock",
 ]
 
 [[package]]
@@ -196,15 +151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,26 +175,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -527,7 +453,6 @@ name = "fediproto-sync"
 version = "0.1.0"
 dependencies = [
  "atprotolib-rs",
- "boring",
  "bytes",
  "chrono",
  "diesel",
@@ -537,6 +462,7 @@ dependencies = [
  "git-version",
  "megalodon",
  "oauth2",
+ "openssl",
  "rand",
  "reqwest 0.12.9",
  "serde",
@@ -565,30 +491,18 @@ checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
 
 [[package]]
 name = "foreign-types"
-version = "0.5.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-macros",
  "foreign-types-shared",
 ]
 
 [[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "foreign-types-shared"
-version = "0.3.1"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -597,22 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fslock"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -743,12 +641,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
@@ -1154,15 +1046,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,16 +1072,6 @@ name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1332,12 +1205,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,16 +1229,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nu-ansi-term"
@@ -1434,6 +1291,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1321,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1623,7 +1507,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "rustls 0.23.19",
  "socket2",
  "thiserror 2.0.4",
@@ -1641,7 +1525,7 @@ dependencies = [
  "getrandom",
  "rand",
  "ring",
- "rustc-hash 2.1.0",
+ "rustc-hash",
  "rustls 0.23.19",
  "rustls-pki-types",
  "slab",
@@ -1863,12 +1747,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM} docker.io/library/rust:1-bookworm AS build
+FROM --platform=${BUILDPLATFORM} docker.io/library/rust:1-bookworm AS build
 
 ARG TARGETPLATFORM
 ARG TARGETARCH
@@ -18,18 +18,16 @@ RUN apt-get update \
         crossbuild-essential-amd64 \
         git \
         pkg-config \
-        cmake \
-        clang \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
     
 RUN chmod +x ./docker-build/build.sh \
     && ./docker-build/build.sh
 
-FROM --platform=${TARGETPLATFORM} docker.io/library/debian:bookworm-slim
+FROM --platform=${TARGETARCH:-$BUILDPLATFORM} docker.io/library/debian:bookworm-slim
 
 RUN apt-get update \
-    && apt-get install -y libsqlite3-0 libpq5 ca-certificates \
+    && apt-get install -y libsqlite3-0 libpq5 openssl ca-certificates \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -8,9 +8,12 @@ case "${TARGETPLATFORM}" in
         export CC_x86_64_unknown_linux_gnu="x86_64-linux-gnu-gcc"
         export CXX_x86_64_unknown_linux_gnu="x86_64-linux-gnu-g++"
 
+        #export X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR="/usr/lib/x86_64-linux-gnu/"
+        #export X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR=""
+
         dpkg --add-architecture amd64
         apt-get update
-        apt-get install -y libpq-dev:amd64 libpq5:amd64 libsqlite3-dev:amd64 libsqlite3-0:amd64
+        apt-get install -y libpq-dev:amd64 libpq5:amd64 libsqlite3-dev:amd64 libsqlite3-0:amd64 libssl-dev:amd64
         apt-get clean
         rm -rf /var/lib/apt/lists/*
         ;;
@@ -22,7 +25,7 @@ case "${TARGETPLATFORM}" in
 
         dpkg --add-architecture arm64
         apt-get update
-        apt-get install -y libpq-dev:arm64 libpq5:arm64 libsqlite3-dev:arm64 libsqlite3-0:arm64
+        apt-get install -y libpq-dev:arm64 libpq5:arm64 libsqlite3-dev:arm64 libsqlite3-0:arm64 libssl-dev:arm64
         apt-get clean
         rm -rf /var/lib/apt/lists/*
         ;;
@@ -36,6 +39,7 @@ echo "${RUST_TARGET}"
 
 export FEDIPROTOSYNC_INCLUDE_COMMIT_HASH="true"
 export FEDIPROTOSYNC_UPDATE_MANIFEST_VERSION="true"
+export PKG_CONFIG_SYSROOT_DIR=/
 
 rustup default nightly
 rustup target add --toolchain "nightly" "${RUST_TARGET}"

--- a/fediproto-sync/Cargo.toml
+++ b/fediproto-sync/Cargo.toml
@@ -42,7 +42,7 @@ uuid = { version = "1.11.0", features = ["v4", "v7", "fast-rng"] }
 oauth2 = "4.4.2"
 url = "2.5.4"
 bytes = "1.9.0"
-boring = "4.13.0"
+openssl = "0.10.68"
 
 [build-dependencies]
 git-version = "0.3.9"

--- a/fediproto-sync/src/config.rs
+++ b/fediproto-sync/src/config.rs
@@ -14,10 +14,10 @@ pub struct FediProtoSyncEnvVars {
     pub database_url: String,
 
     /// The encryption key to use for token encryption.
-    pub token_encryption_private_key: Option<boring::rsa::Rsa<boring::pkey::Private>>,
+    pub token_encryption_private_key: Option<openssl::rsa::Rsa<openssl::pkey::Private>>,
 
     /// The encryption IV to use for token encryption.
-    pub token_encryption_public_key: Option<boring::rsa::Rsa<boring::pkey::Public>>,
+    pub token_encryption_public_key: Option<openssl::rsa::Rsa<openssl::pkey::Public>>,
 
     /// User-Agent string to use for HTTP requests.
     pub user_agent: String,
@@ -107,7 +107,7 @@ impl FediProtoSyncEnvVars {
                         Box::new(e)
                     )
                 })?;
-                let private_key = boring::base64::decode_block(&private_key).map_err(|e| {
+                let private_key = openssl::base64::decode_block(&private_key).map_err(|e| {
                     crate::error::Error::with_source(
                         "Failed to decode the TOKEN_ENCRYPTION_PRIVATE_KEY environment variable.",
                         crate::error::ErrorKind::EnvironmentVariableError,
@@ -115,7 +115,7 @@ impl FediProtoSyncEnvVars {
                     )
                 })?;
                 let private_key =
-                    boring::rsa::Rsa::private_key_from_pem(&private_key).map_err(|e| {
+                    openssl::rsa::Rsa::private_key_from_pem(&private_key).map_err(|e| {
                         crate::error::Error::with_source(
                             "Failed to decode TOKEN_ENCRYPTION_PRIVATE_KEY environment variable.",
                             crate::error::ErrorKind::EnvironmentVariableError,
@@ -139,7 +139,7 @@ impl FediProtoSyncEnvVars {
                         Box::new(e)
                     )
                 })?;
-                let public_key = boring::base64::decode_block(&public_key).map_err(|e| {
+                let public_key = openssl::base64::decode_block(&public_key).map_err(|e| {
                     crate::error::Error::with_source(
                         "Failed to decode the TOKEN_ENCRYPTION_PUBLIC_KEY environment variable.",
                         crate::error::ErrorKind::EnvironmentVariableError,
@@ -147,7 +147,7 @@ impl FediProtoSyncEnvVars {
                     )
                 })?;
                 let public_key =
-                    boring::rsa::Rsa::public_key_from_pem(&public_key).map_err(|e| {
+                    openssl::rsa::Rsa::public_key_from_pem(&public_key).map_err(|e| {
                         crate::error::Error::with_source(
                             "Failed to decode TOKEN_ENCRYPTION_PUBLIC_KEY environment variable.",
                             crate::error::ErrorKind::EnvironmentVariableError,

--- a/fediproto-sync/src/crypto.rs
+++ b/fediproto-sync/src/crypto.rs
@@ -5,19 +5,19 @@
 /// 
 /// * `public_key` - The public key to use for encryption.
 pub fn encrypt_string(
-    public_key: &boring::rsa::Rsa<boring::pkey::Public>,
+    public_key: &openssl::rsa::Rsa<openssl::pkey::Public>,
     input_string: &str
 ) -> Result<String, crate::error::Error> {
     let mut encrypted_string = vec![0; public_key.size() as usize];
 
-    public_key.public_encrypt(input_string.as_bytes(), &mut encrypted_string, boring::rsa::Padding::PKCS1)
+    public_key.public_encrypt(input_string.as_bytes(), &mut encrypted_string, openssl::rsa::Padding::PKCS1)
         .map_err(|e| crate::error::Error::with_source(
             "Failed to encrypt string",
             crate::error::ErrorKind::EncryptionError,
             Box::new(e)
         ))?;
 
-    let encoded_string = boring::base64::encode_block(&encrypted_string);
+    let encoded_string = openssl::base64::encode_block(&encrypted_string);
 
     Ok(encoded_string)
 }
@@ -28,19 +28,19 @@ pub fn encrypt_string(
 /// 
 /// * `private_key` - The private key to use for decryption.
 pub fn decrypt_string(
-    private_key: &boring::rsa::Rsa<boring::pkey::Private>,
+    private_key: &openssl::rsa::Rsa<openssl::pkey::Private>,
     input_string: &str
 ) -> Result<String, crate::error::Error> {
     let mut decrypted_string = vec![0; private_key.size() as usize];
 
-    let encrypted_string = boring::base64::decode_block(input_string)
+    let encrypted_string = openssl::base64::decode_block(input_string)
         .map_err(|e| crate::error::Error::with_source(
             "Failed to decode base64 string",
             crate::error::ErrorKind::DecryptionError,
             Box::new(e)
         ))?;
 
-    let decrypted_length = private_key.private_decrypt(&encrypted_string, &mut decrypted_string, boring::rsa::Padding::PKCS1)
+    let decrypted_length = private_key.private_decrypt(&encrypted_string, &mut decrypted_string, openssl::rsa::Padding::PKCS1)
         .map_err(|e| crate::error::Error::with_source(
             "Failed to decrypt string",
             crate::error::ErrorKind::DecryptionError,

--- a/fediproto-sync/src/db/models.rs
+++ b/fediproto-sync/src/db/models.rs
@@ -277,7 +277,7 @@ pub trait CachedServiceTokenDecrypt {
     /// * `encryption_private_key` - The private key to use for decryption.
      fn decrypt_access_token(
         &self,
-        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
+        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
     ) -> Result<String, crate::error::Error>;
 
     /// Decrypt the refresh token.
@@ -292,7 +292,7 @@ pub trait CachedServiceTokenDecrypt {
     #[allow(dead_code)]
      fn decrypt_refresh_token(
         &self,
-        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
+        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
     ) -> Result<Option<String>, crate::error::Error>;
 }
 
@@ -304,7 +304,7 @@ impl CachedServiceTokenDecrypt for CachedServiceToken {
     /// * `encryption_private_key` - The private key to use for decryption.
      fn decrypt_access_token(
         &self,
-        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
+        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
     ) -> Result<String, crate::error::Error> {
         let decrypted_access_token = crate::crypto::decrypt_string(encryption_private_key, &self.access_token)?;
 
@@ -323,7 +323,7 @@ impl CachedServiceTokenDecrypt for CachedServiceToken {
     #[allow(dead_code)]
      fn decrypt_refresh_token(
         &self,
-        encryption_private_key: &boring::rsa::Rsa<boring::pkey::Private>
+        encryption_private_key: &openssl::rsa::Rsa<openssl::pkey::Private>
     ) -> Result<Option<String>, crate::error::Error> {
         let decrypted_refresh_token = match &self.refresh_token {
             Some(refresh_token) => {
@@ -374,7 +374,7 @@ impl NewCachedServiceToken {
     /// * `expires_in` - The time in seconds until the access token expires, if any.
     /// * `scopes` - The scopes the access token has, if any.
     pub fn new(
-        encryption_public_key: &boring::rsa::Rsa<boring::pkey::Public>,
+        encryption_public_key: &openssl::rsa::Rsa<openssl::pkey::Public>,
         service_name: &str,
         access_token: &str,
         refresh_token: Option<String>,


### PR DESCRIPTION
## Description

- Reverting from using `boring` to `openssl`. BoringSSL would not cross-compile correctly, so I've fixed OpenSSL being cross-compiled.
- In addition this reverts back how I brute forced cross compilation for the container images recently.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#16 :point\_left:
