### PR TITLE
Rename FediProtoSynEnvVars to FediProtoSyncConfig

### DIFF
--- a/fediproto-sync-lib/src/config.rs
+++ b/fediproto-sync-lib/src/config.rs
@@ -3,10 +3,10 @@ use crate::{
     GIT_VERSION
 };
 
-/// The environment variable values for configuring the FediProtoSync
+/// Config values for configuring the FediProtoSync
 /// application.
 #[derive(Debug, Clone)]
-pub struct FediProtoSyncEnvVars {
+pub struct FediProtoSyncConfig {
     /// The mode to run the application in.
     pub mode: String,
 
@@ -61,8 +61,8 @@ pub struct FediProtoSyncEnvVars {
     pub bluesky_video_always_fallback: bool
 }
 
-impl FediProtoSyncEnvVars {
-    /// Create a new instance of the `FediProtoSyncEnvVars` struct.
+impl FediProtoSyncConfig {
+    /// Create a new instance of the `FediProtoSyncConfig` struct.
     pub fn new() -> Result<Self, FediProtoSyncError> {
         // Read 'FEDIPROTO_SYNC_MODE' environment variable.
         let mode = std::env::var("FEDIPROTO_SYNC_MODE").unwrap_or("normal".to_string());

--- a/fediproto-sync/src/auth.rs
+++ b/fediproto-sync/src/auth.rs
@@ -1,11 +1,11 @@
 use fediproto_sync_lib::{
-    config::FediProtoSyncEnvVars,
+    config::FediProtoSyncConfig,
     error::{FediProtoSyncError, FediProtoSyncErrorKind}
 };
 use oauth2::{basic::BasicClient, reqwest::async_http_client};
 
 pub async fn get_mastodon_oauth_token(
-    config: &FediProtoSyncEnvVars
+    config: &FediProtoSyncConfig
 ) -> Result<
     oauth2::StandardTokenResponse<oauth2::EmptyExtraTokenFields, oauth2::basic::BasicTokenType>,
     FediProtoSyncError

--- a/fediproto-sync/src/bsky/mod.rs
+++ b/fediproto-sync/src/bsky/mod.rs
@@ -17,7 +17,7 @@ use fediproto_sync_lib::error::{FediProtoSyncError, FediProtoSyncErrorKind};
 
 use crate::{
     bsky::{media::BlueSkyPostSyncMedia, rich_text::BlueSkyPostSyncRichText},
-    FediProtoSyncEnvVars
+    FediProtoSyncConfig
 };
 
 /// Holds the authentication information for a Bluesky session.
@@ -42,7 +42,7 @@ impl BlueSkyAuthentication {
     ///   application.
     /// * `client` - The reqwest client to use for the API request.
     pub async fn new(
-        config: &FediProtoSyncEnvVars,
+        config: &FediProtoSyncConfig,
         client: reqwest::Client
     ) -> Result<Self, FediProtoSyncError> {
         let config = config.clone();
@@ -125,7 +125,7 @@ impl BlueSkyAuthentication {
 /// Struct to hold the data and logic for syncing a Mastodon post to BlueSky.
 pub struct BlueSkyPostSync<'a> {
     /// The environment variables for the FediProto Sync application.
-    pub config: FediProtoSyncEnvVars,
+    pub config: FediProtoSyncConfig,
 
     /// The authentication session for BlueSky.
     pub bsky_auth: BlueSkyAuthentication,

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -2,7 +2,7 @@ use atprotolib_rs::types::app_bsky;
 use diesel::r2d2::{ConnectionManager, Pool};
 use fediproto_sync_db::{models::{self, CachedServiceTokenDecrypt}, AnyConnection};
 use fediproto_sync_lib::{
-    config::{self, FediProtoSyncEnvVars},
+    config::{self, FediProtoSyncConfig},
     error::{FediProtoSyncError, FediProtoSyncErrorKind}
 };
 
@@ -13,7 +13,7 @@ use crate::{bsky, mastodon::MastodonApiExtensions};
 /// The main sync loop for the FediProto Sync application.
 pub struct FediProtoSyncLoop {
     /// The environment variables for the FediProto Sync application.
-    config: FediProtoSyncEnvVars,
+    config: FediProtoSyncConfig,
 
     /// The database connection for the FediProto Sync application.
     db_connection: Pool<ConnectionManager<AnyConnection>>,
@@ -29,7 +29,7 @@ impl FediProtoSyncLoop {
     ///
     /// * `config` - The environment variables for the FediProtoSync
     ///   application.
-    pub async fn new(config: &FediProtoSyncEnvVars, db_connection: Pool<ConnectionManager<AnyConnection>>) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(config: &FediProtoSyncConfig, db_connection: Pool<ConnectionManager<AnyConnection>>) -> Result<Self, Box<dyn std::error::Error>> {
         let config = config.clone();
 
         let client = create_http_client(&config)?;
@@ -306,7 +306,7 @@ impl FediProtoSyncLoop {
 ///
 /// * `config` - The environment variables for the FediProto Sync application.
 pub fn create_http_client(
-    config: &FediProtoSyncEnvVars
+    config: &FediProtoSyncConfig
 ) -> Result<reqwest::Client, FediProtoSyncError> {
     reqwest::Client::builder()
         .user_agent(config.user_agent.clone())

--- a/fediproto-sync/src/main.rs
+++ b/fediproto-sync/src/main.rs
@@ -3,7 +3,7 @@ mod bsky;
 mod core;
 mod mastodon;
 
-use fediproto_sync_lib::config::FediProtoSyncEnvVars;
+use fediproto_sync_lib::config::FediProtoSyncConfig;
 
 use diesel::prelude::*;
 use diesel::r2d2::ConnectionManager;
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let _ = dotenvy::from_path(env_vars_path)?;
     }
 
-    let config_result = FediProtoSyncEnvVars::new();
+    let config_result = FediProtoSyncConfig::new();
 
     let config = match config_result {
         Ok(config) => config,


### PR DESCRIPTION
## Description

Renames `FediProtoSyncEnvVars` to `FediProtoSyncConfig` to better clarify what it is.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#19 :point\_left:
