### PR TITLE
Improve image upload memory usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1079,9 +1079,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1129,7 +1129,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -1143,7 +1143,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.2.0",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-util",
  "rustls 0.23.20",
  "rustls-pki-types",
@@ -1164,7 +1164,7 @@ dependencies = [
  "futures-util",
  "http 1.2.0",
  "http-body 1.0.1",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1468,7 +1468,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "thiserror 1.0.69",
+ "thiserror 2.0.7",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
@@ -2006,7 +2006,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.31",
+ "hyper 0.14.32",
  "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
@@ -2046,7 +2046,7 @@ dependencies = [
  "http 1.2.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.1",
+ "hyper 1.5.2",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 [[package]]
 name = "atprotolib-rs"
 version = "0.1.0"
-source = "git+https://github.com/Smalls1652/atprotolib-rs.git#8062286a784069c5405a89db44bdd95e0c07b17d"
+source = "git+https://github.com/Smalls1652/atprotolib-rs.git#88e5af99dd8b92f1d1955dfe31f14af5ffac17db"
 dependencies = [
  "chrono",
  "reqwest 0.12.9",
@@ -1468,7 +1468,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
- "thiserror 2.0.7",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",

--- a/fediproto-sync/src/bsky/media.rs
+++ b/fediproto-sync/src/bsky/media.rs
@@ -70,12 +70,22 @@ pub trait BlueSkyPostSyncMedia {
         file_path: &std::path::PathBuf
     ) -> Result<Option<app_bsky::feed::PostEmbeds>, Box<dyn std::error::Error>>;
 
-    /// Download a media attachment from a Mastodon status to a temporary file.
+    /// Download a media attachment from a Mastodon status.
     ///
     /// ## Arguments
     ///
     /// * `media_attachment` - The media attachment to download.
     async fn download_mastodon_media_attachment(
+        &mut self,
+        media_attachment: &megalodon::entities::attachment::Attachment
+    ) -> Result<reqwest::Response, Box<dyn std::error::Error>>;
+
+    /// Download a media attachment from a Mastodon status to a temporary file.
+    ///
+    /// ## Arguments
+    ///
+    /// * `media_attachment` - The media attachment to download.
+    async fn download_mastodon_media_attachment_to_file(
         &mut self,
         media_attachment: &megalodon::entities::attachment::Attachment
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>>;
@@ -97,12 +107,11 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
 
         for image_attachment in media_attachments {
             // Download the media attachment from the Mastodon server.
-            let media_attachment_client = crate::core::create_http_client(&self.config)?;
-            let media_attachment_response = media_attachment_client
-                .get(&image_attachment.url)
-                .send()
+            let media_attachment_temp_path = self
+                .download_mastodon_media_attachment_to_file(image_attachment)
                 .await?;
-            let media_attachment_bytes = media_attachment_response.bytes().await?;
+
+            let media_attachment_temp_file = tokio::fs::File::open(&media_attachment_temp_path).await?;
 
             let blob_upload_client = crate::core::create_http_client(&self.config)?;
             // Upload the media attachment to Bluesky.
@@ -110,10 +119,12 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
                 &self.bsky_auth.host_name,
                 blob_upload_client,
                 &self.bsky_auth.auth_config,
-                media_attachment_bytes.to_vec(),
+                media_attachment_temp_file,
                 Some("image/jpeg")
             )
             .await?;
+
+            tokio::fs::remove_file(&media_attachment_temp_path).await?;
 
             // Create an image embed and add it to the list of image attachments.
             image_attachments.push(app_bsky::embed::ImageEmbed {
@@ -150,7 +161,9 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
         media_attachment: &megalodon::entities::attachment::Attachment
     ) -> Result<Option<app_bsky::feed::PostEmbeds>, Box<dyn std::error::Error>> {
         #[allow(unused_assignments)]
-        let temp_file_path = self.download_mastodon_media_attachment(media_attachment).await?;
+        let temp_file_path = self
+            .download_mastodon_media_attachment_to_file(media_attachment)
+            .await?;
 
         let new_cached_file_record = NewCachedFile::new(&temp_file_path);
         fediproto_sync_db::operations::insert_cached_file_record(
@@ -201,6 +214,7 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
         let video_link_thumbnail_bytes = self
             .get_link_thumbnail(media_attachment.preview_url.clone().unwrap().as_str())
             .await?;
+        let video_link_thumbnail_bytes = video_link_thumbnail_bytes.bytes().await?;
 
         let blob_item = match video_link_thumbnail_bytes.len() > 0 {
             true => {
@@ -352,7 +366,7 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
         }
     }
 
-    /// Download a media attachment from a Mastodon status to a temporary file.
+    /// Download a media attachment from a Mastodon status.
     ///
     /// ## Arguments
     ///
@@ -360,17 +374,31 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
     async fn download_mastodon_media_attachment(
         &mut self,
         media_attachment: &megalodon::entities::attachment::Attachment
-    ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    ) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
         tracing::info!(
             "Downloading media attachment '{}' from Mastodon",
             media_attachment.url
         );
 
         let media_attachment_client = crate::core::create_http_client(&self.config)?;
-        let mut media_attachment_response = media_attachment_client
+        let media_attachment_response = media_attachment_client
             .get(&media_attachment.url)
             .send()
             .await?;
+
+        Ok(media_attachment_response)
+    }
+
+    /// Download a media attachment from a Mastodon status to a temporary file.
+    ///
+    /// ## Arguments
+    ///
+    /// * `media_attachment` - The media attachment to download.
+    async fn download_mastodon_media_attachment_to_file(
+        &mut self,
+        media_attachment: &megalodon::entities::attachment::Attachment
+    ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+        let mut media_attachment_response = self.download_mastodon_media_attachment(media_attachment).await?;
 
         let temp_path = std::env::temp_dir()
             .join(rand::distributions::Alphanumeric.sample_string(&mut rand::thread_rng(), 14));

--- a/fediproto-sync/src/bsky/media.rs
+++ b/fediproto-sync/src/bsky/media.rs
@@ -70,12 +70,12 @@ pub trait BlueSkyPostSyncMedia {
         file_path: &std::path::PathBuf
     ) -> Result<Option<app_bsky::feed::PostEmbeds>, Box<dyn std::error::Error>>;
 
-    /// Download a video from a Mastodon status to a temporary file.
+    /// Download a media attachment from a Mastodon status to a temporary file.
     ///
     /// ## Arguments
     ///
     /// * `media_attachment` - The media attachment to download.
-    async fn download_mastodon_video(
+    async fn download_mastodon_media_attachment(
         &mut self,
         media_attachment: &megalodon::entities::attachment::Attachment
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>>;
@@ -150,7 +150,7 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
         media_attachment: &megalodon::entities::attachment::Attachment
     ) -> Result<Option<app_bsky::feed::PostEmbeds>, Box<dyn std::error::Error>> {
         #[allow(unused_assignments)]
-        let temp_file_path = self.download_mastodon_video(media_attachment).await?;
+        let temp_file_path = self.download_mastodon_media_attachment(media_attachment).await?;
 
         let new_cached_file_record = NewCachedFile::new(&temp_file_path);
         fediproto_sync_db::operations::insert_cached_file_record(
@@ -352,17 +352,17 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
         }
     }
 
-    /// Download a video from a Mastodon status to a temporary file.
+    /// Download a media attachment from a Mastodon status to a temporary file.
     ///
     /// ## Arguments
     ///
     /// * `media_attachment` - The media attachment to download.
-    async fn download_mastodon_video(
+    async fn download_mastodon_media_attachment(
         &mut self,
         media_attachment: &megalodon::entities::attachment::Attachment
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
         tracing::info!(
-            "Downloading video attachment '{}' from Mastodon",
+            "Downloading media attachment '{}' from Mastodon",
             media_attachment.url
         );
 

--- a/fediproto-sync/src/bsky/rich_text.rs
+++ b/fediproto-sync/src/bsky/rich_text.rs
@@ -2,6 +2,7 @@ use atprotolib_rs::types::{
     app_bsky::{self, richtext::RichTextFacet},
     com_atproto
 };
+use bytes::Bytes;
 
 use super::BlueSkyPostSync;
 use crate::bsky::utils::BlueSkyPostSyncUtils;
@@ -130,8 +131,12 @@ impl BlueSkyPostSyncRichText for BlueSkyPostSync<'_> {
             // Get the thumbnail for the link if it has one and upload it to BlueSky.
             let link_thumbnail_url = link_metadata["image"].as_str().unwrap_or_else(|| "");
             let link_thumbnail_bytes = match link_thumbnail_url == "" {
-                true => vec![],
-                false => self.get_link_thumbnail(link_thumbnail_url).await?
+                true => Bytes::new(),
+                false => {
+                    let link_thumbnail = self.get_link_thumbnail(link_thumbnail_url).await?;
+
+                    link_thumbnail.bytes().await?
+                }
             };
 
             let blob_item = match link_thumbnail_bytes.len() > 0 {

--- a/fediproto-sync/src/bsky/utils.rs
+++ b/fediproto-sync/src/bsky/utils.rs
@@ -23,7 +23,7 @@ pub trait BlueSkyPostSyncUtils {
     async fn get_link_thumbnail(
         &mut self,
         image_url: &str
-    ) -> Result<Vec<u8>, Box<dyn std::error::Error>>;
+    ) -> Result<reqwest::Response, Box<dyn std::error::Error>>;
 
     /// Get the PDS service endpoint from the Bluesky session.
     fn get_pds_service_endpoint(&mut self) -> Result<String, Box<dyn std::error::Error>>;
@@ -63,16 +63,14 @@ impl BlueSkyPostSyncUtils for BlueSkyPostSync<'_> {
     async fn get_link_thumbnail(
         &mut self,
         image_url: &str
-    ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    ) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
         tracing::info!("Getting link thumbnail for '{}'.", image_url);
 
         let link_thumbnail_client = crate::core::create_http_client(&self.config)?;
 
         let link_thumbnail_response = link_thumbnail_client.get(image_url).send().await?;
 
-        let link_thumbnail_bytes = link_thumbnail_response.bytes().await?;
-
-        Ok(link_thumbnail_bytes.to_vec())
+        Ok(link_thumbnail_response)
     }
 
     /// Get the PDS service endpoint from the Bluesky session.


### PR DESCRIPTION
## Description

This PR takes [some of the improvements made with video uploads](https://github.com/Smalls1652/fediproto-sync/commit/f22215e5938bf7e25b12e11ff4fb1b5070b59b6a) and applies it to any image upload. These changes should help reduce memory usage (Even if it's negligible in the first place and overall memory usage for the process is typically really low anyway).

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#21 :point\_left:
