### PR TITLE
Modify BlueSky post sync database usage

### DIFF
--- a/fediproto-sync/src/bsky/media.rs
+++ b/fediproto-sync/src/bsky/media.rs
@@ -160,6 +160,8 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync {
         &mut self,
         media_attachment: &megalodon::entities::attachment::Attachment
     ) -> Result<Option<app_bsky::feed::PostEmbeds>, Box<dyn std::error::Error>> {
+        let db_connection = &mut self.db_connection_pool.get()?;
+
         #[allow(unused_assignments)]
         let temp_file_path = self
             .download_mastodon_media_attachment_to_file(media_attachment)
@@ -167,7 +169,7 @@ impl BlueSkyPostSyncMedia for BlueSkyPostSync {
 
         let new_cached_file_record = NewCachedFile::new(&temp_file_path);
         fediproto_sync_db::operations::insert_cached_file_record(
-            self.db_connection,
+            db_connection,
             &new_cached_file_record
         )?;
 

--- a/fediproto-sync/src/bsky/media.rs
+++ b/fediproto-sync/src/bsky/media.rs
@@ -91,7 +91,7 @@ pub trait BlueSkyPostSyncMedia {
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>>;
 }
 
-impl BlueSkyPostSyncMedia for BlueSkyPostSync<'_> {
+impl BlueSkyPostSyncMedia for BlueSkyPostSync {
     /// Generate an image embed for a BlueSky post from media attachments from
     /// a Mastodon status.
     ///

--- a/fediproto-sync/src/bsky/mod.rs
+++ b/fediproto-sync/src/bsky/mod.rs
@@ -123,7 +123,7 @@ impl BlueSkyAuthentication {
 }
 
 /// Struct to hold the data and logic for syncing a Mastodon post to BlueSky.
-pub struct BlueSkyPostSync<'a> {
+pub struct BlueSkyPostSync {
     /// The environment variables for the FediProto Sync application.
     pub config: FediProtoSyncConfig,
 
@@ -143,7 +143,7 @@ pub struct BlueSkyPostSync<'a> {
     pub post_item: app_bsky::feed::Post
 }
 
-impl BlueSkyPostSync<'_> {
+impl BlueSkyPostSync {
     /// Sync a Mastodon post to Bluesky.
     pub async fn sync_post(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         // -- Generate a BlueSky post item from the Mastodon status. --

--- a/fediproto-sync/src/bsky/rich_text.rs
+++ b/fediproto-sync/src/bsky/rich_text.rs
@@ -30,7 +30,7 @@ pub trait BlueSkyPostSyncRichText {
     ) -> Result<Vec<RichTextFacet>, Box<dyn std::error::Error>>;
 }
 
-impl BlueSkyPostSyncRichText for BlueSkyPostSync<'_> {
+impl BlueSkyPostSyncRichText for BlueSkyPostSync {
     /// Generate rich text tags for the post item.
     ///
     /// ## Arguments

--- a/fediproto-sync/src/bsky/utils.rs
+++ b/fediproto-sync/src/bsky/utils.rs
@@ -29,7 +29,7 @@ pub trait BlueSkyPostSyncUtils {
     fn get_pds_service_endpoint(&mut self) -> Result<String, Box<dyn std::error::Error>>;
 }
 
-impl BlueSkyPostSyncUtils for BlueSkyPostSync<'_> {
+impl BlueSkyPostSyncUtils for BlueSkyPostSync {
     /// Get link metadata from the CardyB API.
     ///
     /// ## Arguments

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -188,7 +188,7 @@ impl FediProtoSyncLoop {
 
             let mut post_sync = bsky::BlueSkyPostSync {
                 config: self.config.clone(),
-                db_connection: db_connection,
+                db_connection_pool: self.db_connection.clone(),
                 bsky_auth: self.bsky_auth.clone(),
                 mastodon_account: account.json.clone(),
                 mastodon_status: post_item.clone(),


### PR DESCRIPTION
## Description

- Switches the usage of the database connection to a pooled database connection in `BlueSkyPostSync`.
- Removes lifetime from `BlueSkyPostSync`.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#22 :point\_left:
