### PR TITLE
Add retries for posts that fail to sync

### DIFF
--- a/fediproto-sync-db/Cargo.toml
+++ b/fediproto-sync-db/Cargo.toml
@@ -28,6 +28,9 @@ tokio = { version = "1.42.0", features = ["io-std", "io-util"] }
 tracing = "0.1.41"
 uuid = { version = "1.11.0", features = ["fast-rng", "v4", "v7"] }
 
+[features]
+local_dev = []
+
 [build-dependencies]
 git-version = "0.3.9"
 toml_edit = "0.22.22"

--- a/fediproto-sync-db/migrations/postgres/2024-12-19-171140_add_mastodon_post_retry_queue/down.sql
+++ b/fediproto-sync-db/migrations/postgres/2024-12-19-171140_add_mastodon_post_retry_queue/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+
+
+
+
+DROP TABLE IF EXISTS "mastodon_post_retry_queue";

--- a/fediproto-sync-db/migrations/postgres/2024-12-19-171140_add_mastodon_post_retry_queue/up.sql
+++ b/fediproto-sync-db/migrations/postgres/2024-12-19-171140_add_mastodon_post_retry_queue/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+
+
+
+
+CREATE TABLE "mastodon_post_retry_queue"(
+	"id" UUID NOT NULL PRIMARY KEY,
+	"mastodon_post_id" VARCHAR NOT NULL,
+	"failure_reason" VARCHAR NOT NULL
+);
+

--- a/fediproto-sync-db/migrations/postgres/2024-12-19-171140_add_mastodon_post_retry_queue/up.sql
+++ b/fediproto-sync-db/migrations/postgres/2024-12-19-171140_add_mastodon_post_retry_queue/up.sql
@@ -4,8 +4,9 @@
 
 
 CREATE TABLE "mastodon_post_retry_queue"(
-	"id" UUID NOT NULL PRIMARY KEY,
-	"mastodon_post_id" VARCHAR NOT NULL,
-	"failure_reason" VARCHAR NOT NULL
+	"id" BIGINT NOT NULL PRIMARY KEY,
+	"failure_reason" VARCHAR NOT NULL,
+	"last_retried_at" TIMESTAMP NOT NULL,
+	"retry_count" INTEGER NOT NULL
 );
 

--- a/fediproto-sync-db/migrations/sqlite/2024-12-19-170459_add_mastodon_post_retry_queue/down.sql
+++ b/fediproto-sync-db/migrations/sqlite/2024-12-19-170459_add_mastodon_post_retry_queue/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+
+
+
+
+DROP TABLE IF EXISTS `mastodon_post_retry_queue`;

--- a/fediproto-sync-db/migrations/sqlite/2024-12-19-170459_add_mastodon_post_retry_queue/up.sql
+++ b/fediproto-sync-db/migrations/sqlite/2024-12-19-170459_add_mastodon_post_retry_queue/up.sql
@@ -1,0 +1,11 @@
+-- Your SQL goes here
+
+
+
+
+CREATE TABLE `mastodon_post_retry_queue`(
+	`id` TEXT NOT NULL PRIMARY KEY,
+	`mastodon_post_id` TEXT NOT NULL,
+	`failure_reason` TEXT NOT NULL
+);
+

--- a/fediproto-sync-db/migrations/sqlite/2024-12-19-170459_add_mastodon_post_retry_queue/up.sql
+++ b/fediproto-sync-db/migrations/sqlite/2024-12-19-170459_add_mastodon_post_retry_queue/up.sql
@@ -4,8 +4,9 @@
 
 
 CREATE TABLE `mastodon_post_retry_queue`(
-	`id` TEXT NOT NULL PRIMARY KEY,
-	`mastodon_post_id` TEXT NOT NULL,
-	`failure_reason` TEXT NOT NULL
+	`id` BIGINT NOT NULL PRIMARY KEY,
+	`failure_reason` TEXT NOT NULL,
+	`last_retried_at` TIMESTAMP NOT NULL,
+	`retry_count` INTEGER NOT NULL
 );
 

--- a/fediproto-sync-db/src/lib.rs
+++ b/fediproto-sync-db/src/lib.rs
@@ -4,6 +4,11 @@ pub mod operations;
 pub mod schema;
 pub mod type_impls;
 
+#[cfg(feature = "local_dev")]
+mod schema_postgres;
+#[cfg(feature = "local_dev")]
+mod schema_sqlite;
+
 use diesel::{
     backend::Backend,
     connection::Connection,

--- a/fediproto-sync-db/src/schema.rs
+++ b/fediproto-sync-db/src/schema.rs
@@ -39,3 +39,11 @@ diesel::table! {
         file_path -> VarChar
     }
 }
+
+diesel::table! {
+    mastodon_post_retry_queue (id) {
+        id -> crate::type_impls::MultiBackendUuid,
+        mastodon_post_id -> VarChar,
+        failure_reason -> VarChar
+    }
+}

--- a/fediproto-sync-db/src/schema.rs
+++ b/fediproto-sync-db/src/schema.rs
@@ -42,8 +42,10 @@ diesel::table! {
 
 diesel::table! {
     mastodon_post_retry_queue (id) {
-        id -> crate::type_impls::MultiBackendUuid,
+        id -> BigInt,
         mastodon_post_id -> VarChar,
-        failure_reason -> VarChar
+        failure_reason -> VarChar,
+        last_retried_at -> Timestamp,
+        retry_count -> Integer
     }
 }

--- a/fediproto-sync-db/src/schema_postgres.rs
+++ b/fediproto-sync-db/src/schema_postgres.rs
@@ -42,8 +42,9 @@ diesel::table! {
 
 diesel::table! {
     mastodon_post_retry_queue (id) {
-        id -> Uuid,
-        mastodon_post_id -> VarChar,
-        failure_reason -> VarChar
+        id -> BigInt,
+        failure_reason -> VarChar,
+        last_retried_at -> Timestamp,
+        retry_count -> Integer
     }
 }

--- a/fediproto-sync-db/src/schema_postgres.rs
+++ b/fediproto-sync-db/src/schema_postgres.rs
@@ -35,7 +35,15 @@ diesel::table! {
         service_name -> VarChar,
         access_token -> VarChar,
         refresh_token -> Nullable<VarChar>,
-        expires_in -> Nullable<Integer>,
+        expires_in -> Nullable<Timestamp>,
         scopes -> Nullable<VarChar>,
+    }
+}
+
+diesel::table! {
+    mastodon_post_retry_queue (id) {
+        id -> Uuid,
+        mastodon_post_id -> VarChar,
+        failure_reason -> VarChar
     }
 }

--- a/fediproto-sync-db/src/schema_sqlite.rs
+++ b/fediproto-sync-db/src/schema_sqlite.rs
@@ -39,3 +39,11 @@ diesel::table! {
         scopes -> Nullable<Text>,
     }
 }
+
+diesel::table! {
+    mastodon_post_retry_queue (id) {
+        id -> Text,
+        mastodon_post_id -> Text,
+        failure_reason -> Text
+    }
+}

--- a/fediproto-sync-db/src/schema_sqlite.rs
+++ b/fediproto-sync-db/src/schema_sqlite.rs
@@ -1,6 +1,33 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    cached_files (id) {
+        id -> Text,
+        file_path -> Text,
+    }
+}
+
+diesel::table! {
+    cached_service_tokens (id) {
+        id -> Text,
+        service_name -> Text,
+        access_token -> Text,
+        refresh_token -> Nullable<Text>,
+        expires_in -> Nullable<Integer>,
+        scopes -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    mastodon_post_retry_queue (id) {
+        id -> BigInt,
+        failure_reason -> Text,
+        last_retried_at -> Timestamp,
+        retry_count -> Integer,
+    }
+}
+
+diesel::table! {
     mastodon_posts (id) {
         id -> Text,
         account_id -> Text,
@@ -22,28 +49,10 @@ diesel::table! {
     }
 }
 
-diesel::table! {
-    cached_files (id) {
-        id -> Text,
-        file_path -> Text
-    }
-}
-
-diesel::table! {
-    cached_service_tokens(id) {
-        id -> Text,
-        service_name -> Text,
-        access_token -> Text,
-        refresh_token -> Nullable<Text>,
-        expires_in -> Nullable<Integer>,
-        scopes -> Nullable<Text>,
-    }
-}
-
-diesel::table! {
-    mastodon_post_retry_queue (id) {
-        id -> Text,
-        mastodon_post_id -> Text,
-        failure_reason -> Text
-    }
-}
+diesel::allow_tables_to_appear_in_same_query!(
+    cached_files,
+    cached_service_tokens,
+    mastodon_post_retry_queue,
+    mastodon_posts,
+    synced_posts_bluesky_data,
+);

--- a/fediproto-sync/src/bsky/mod.rs
+++ b/fediproto-sync/src/bsky/mod.rs
@@ -168,6 +168,21 @@ impl BlueSkyPostSync {
         {
             let in_reply_to_id = self.mastodon_status.in_reply_to_id.clone().unwrap();
 
+            match fediproto_sync_db::operations::check_synced_mastodon_post_exists(
+                db_connection,
+                &in_reply_to_id
+            )? {
+                true => {}
+
+                false => {
+                    return Err(Box::new(FediProtoSyncError::new(
+                        format!("Previous post '{}' not found in database.", &in_reply_to_id)
+                            .as_str(),
+                        FediProtoSyncErrorKind::DatabaseQueryError
+                    )));
+                }
+            };
+
             // Resolve the previous post in the thread and resolve it's synced post data.
             let previous_mastodon_post =
                 fediproto_sync_db::operations::get_synced_mastodon_post_by_id(

--- a/fediproto-sync/src/bsky/rich_text.rs
+++ b/fediproto-sync/src/bsky/rich_text.rs
@@ -96,7 +96,10 @@ impl BlueSkyPostSyncRichText for BlueSkyPostSync {
 
             let link_start_index = match link_start_index_filter.len() > 0 {
                 true => link_start_index_filter[0],
-                false => parsed_status.stripped_html.find(&link).unwrap().clone()
+                false => match parsed_status.stripped_html.find(&link) {
+                    Some(index) => index,
+                    None => return Err("Link not found in post content".into())
+                }
             };
 
             let link_end_index = link_start_index + &link.len();


### PR DESCRIPTION
## Description

Adds logic for handling posts that fail to sync. It should help prevent the possibility for posts that fail to be lost to the aether since retrieving new posts is heavily dependent on what the last **successful** synced post was.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#24 :point\_left:
