### PR TITLE
Add basic boost syncing

### DIFF
--- a/fediproto-sync-db/migrations/postgres/2025-01-07-195610_add_is_boosted_post/down.sql
+++ b/fediproto-sync-db/migrations/postgres/2025-01-07-195610_add_is_boosted_post/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+
+
+
+ALTER TABLE "mastodon_posts" DROP COLUMN "is_boosted_post";
+
+

--- a/fediproto-sync-db/migrations/postgres/2025-01-07-195610_add_is_boosted_post/up.sql
+++ b/fediproto-sync-db/migrations/postgres/2025-01-07-195610_add_is_boosted_post/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+
+
+
+ALTER TABLE "mastodon_posts" ADD COLUMN "is_boosted_post" BOOL NOT NULL DEFAULT false;
+
+

--- a/fediproto-sync-db/migrations/sqlite/2025-01-07-195610_add_is_boosted_post/down.sql
+++ b/fediproto-sync-db/migrations/sqlite/2025-01-07-195610_add_is_boosted_post/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+
+
+
+ALTER TABLE `mastodon_posts` DROP COLUMN `is_boosted_post`;
+
+

--- a/fediproto-sync-db/migrations/sqlite/2025-01-07-195610_add_is_boosted_post/up.sql
+++ b/fediproto-sync-db/migrations/sqlite/2025-01-07-195610_add_is_boosted_post/up.sql
@@ -1,0 +1,7 @@
+-- Your SQL goes here
+
+
+
+ALTER TABLE `mastodon_posts` ADD COLUMN `is_boosted_post` BOOL NOT NULL DEFAULT 0;
+
+

--- a/fediproto-sync-db/src/models.rs
+++ b/fediproto-sync-db/src/models.rs
@@ -25,6 +25,9 @@ pub struct MastodonPost {
     /// Whether the post is a thread post.
     pub is_thread_post: bool,
 
+    /// Whether the post is a boosted post.
+    pub is_boosted_post: bool,
+
     /// The previous post ID in the thread, if any.
     pub previous_post_id: Option<String>,
 
@@ -53,6 +56,9 @@ pub struct NewMastodonPost {
 
     /// Whether the post is a thread post.
     pub is_thread_post: bool,
+
+    /// Whether the post is a boosted post.
+    pub is_boosted_post: bool,
 
     /// The previous post ID in the thread, if any.
     pub previous_post_id: Option<String>,
@@ -99,6 +105,8 @@ impl NewMastodonPost {
             false => false
         };
 
+        let is_boosted_post = post.reblog.is_some();
+
         let previous_post_id = match is_thread_post {
             true => Some(post_in_reply_to_id.unwrap()),
             false => None
@@ -110,6 +118,7 @@ impl NewMastodonPost {
             post_id,
             created_at,
             is_thread_post,
+            is_boosted_post,
             previous_post_id,
             bsky_post_id,
             root_mastodon_post_id

--- a/fediproto-sync-db/src/schema.rs
+++ b/fediproto-sync-db/src/schema.rs
@@ -7,6 +7,7 @@ diesel::table! {
         post_id -> VarChar,
         created_at -> Timestamp,
         is_thread_post -> Bool,
+        is_boosted_post -> Bool,
         previous_post_id -> Nullable<VarChar>,
         bsky_post_id -> Nullable<VarChar>,
         root_mastodon_post_id -> Nullable<VarChar>,

--- a/fediproto-sync-db/src/schema_postgres.rs
+++ b/fediproto-sync-db/src/schema_postgres.rs
@@ -7,6 +7,7 @@ diesel::table! {
         post_id -> VarChar,
         created_at -> Timestamp,
         is_thread_post -> Bool,
+        is_boosted_post -> Bool,
         previous_post_id -> Nullable<VarChar>,
         bsky_post_id -> Nullable<VarChar>,
         root_mastodon_post_id -> Nullable<VarChar>,

--- a/fediproto-sync-db/src/schema_sqlite.rs
+++ b/fediproto-sync-db/src/schema_sqlite.rs
@@ -34,6 +34,7 @@ diesel::table! {
         post_id -> Text,
         created_at -> Timestamp,
         is_thread_post -> Bool,
+        is_boosted_post -> Bool,
         previous_post_id -> Nullable<Text>,
         bsky_post_id -> Nullable<Text>,
         root_mastodon_post_id -> Nullable<Text>,

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -230,7 +230,8 @@ impl FediProtoSyncLoop {
                                 langs: None,
                                 reply: None,
                                 tags: None
-                            }
+                            },
+                            previous_post_id: None
                         };
 
                         let sync_result = post_sync.sync_post().await;
@@ -299,7 +300,8 @@ impl FediProtoSyncLoop {
                     langs: None,
                     reply: None,
                     tags: None
-                }
+                },
+                previous_post_id: None
             };
 
             let sync_result = post_sync.sync_post().await;

--- a/fediproto-sync/src/mastodon.rs
+++ b/fediproto-sync/src/mastodon.rs
@@ -32,7 +32,7 @@ impl MastodonApiExtensions for Box<dyn megalodon::Megalodon + Send + Sync> {
             since_id: last_post_id,
             pinned: Some(false),
             exclude_replies: Some(true),
-            exclude_reblogs: Some(true),
+            exclude_reblogs: Some(false),
             only_media: Some(false),
             only_public: Some(true)
         };


### PR DESCRIPTION
## Description

This adds a basic implementation of syncing boosted posts. It does not resolve posts for accounts bridged with Bridgy Fed yet, but it does add a link embed on the BlueSky side.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#40 :point\_left:
