### PR TITLE
Add token encryption key generation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,8 +12,8 @@ You can create an application and get an access token for your account by:
 4. Fill out a name for the application.
 5. Set the **Redirect URI** to `http://localhost:3000/auth/mastodon/authorized`.
 6. Check the following scopes:
-  * `read:statuses`
-  * `profile`
+    * `read:statuses`
+    * `profile`
 7. Click the **"Submit"** button at the bottom.
 8. Copy the **Client key** and **Client secret** values generated.
 
@@ -27,7 +27,23 @@ You can create an application and get an access token for your account by:
 > [!WARNING]
 > Changing these keys will invalidate all existing tokens.
 
-You can generate a public/private key-pair by either running the `./scripts/generateTokenKeys.sh` script or running the following commands:
+You can generate a public/private key-pair a few different ways. The options provided below will output the keys in a `.env` format in the terminal. You can then copy and paste the values into your `.env` file or pipe them directly into the `.env` file.
+
+#### `fediproto-sync`
+
+```bash
+fediproto-sync generate-token-encryption-keys
+```
+
+#### Shell
+
+You can either run a provided shell script:
+
+```bash
+./scripts/generateTokenKeys.sh
+```
+
+Or run the following commands in your terminal:
 
 ```bash
 PRIVATE_KEY_PATH="${TMPDIR}fediproto-private_key.pem"

--- a/fediproto-sync-lib/src/crypto.rs
+++ b/fediproto-sync-lib/src/crypto.rs
@@ -51,3 +51,24 @@ pub fn decrypt_string(
 
     Ok(decrypted_string)
 }
+
+/// Generate a new token encryption key pair.
+pub fn generate_token_encryption_key(
+) -> Result<String, FediProtoSyncError> {
+    let private_key =
+        openssl::rsa::Rsa::generate(2048).map_err(|_| FediProtoSyncError::KeyGenerationError)?;
+
+    let private_key_bytes = private_key
+        .private_key_to_pem()
+        .map_err(|_| FediProtoSyncError::KeyGenerationError)?;
+    let private_key_base64 = openssl::base64::encode_block(&private_key_bytes);
+
+    let public_key_bytes = private_key
+        .public_key_to_pem()
+        .map_err(|_| FediProtoSyncError::KeyGenerationError)?;
+    let public_key_base64 = openssl::base64::encode_block(&public_key_bytes);
+
+    let output_string = format!("TOKEN_ENCRYPTION_PRIVATE_KEY=\"{}\"\nTOKEN_ENCRYPTION_PUBLIC_KEY=\"{}\"", private_key_base64, public_key_base64);
+
+    Ok(output_string)
+}

--- a/fediproto-sync-lib/src/error.rs
+++ b/fediproto-sync-lib/src/error.rs
@@ -20,6 +20,9 @@ pub enum FediProtoSyncError {
     #[error("Invalid database type.")]
     InvalidDatabaseType,
 
+    #[error("Failed to generate key.")]
+    KeyGenerationError,
+
     /// An error occurred while encrypting a value.
     #[error("Failed to encrypt value.")]
     EncryptionError,

--- a/fediproto-sync/src/cli.rs
+++ b/fediproto-sync/src/cli.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+
+/// CLI options for FediProtoSync.
+enum CliOption {
+    /// Generate a token encryption key for the application.
+    GenerateTokenEncryptionKey,
+}
+
+impl std::str::FromStr for CliOption {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "generate-token-encryption-key" => Ok(CliOption::GenerateTokenEncryptionKey),
+            _ => Err(anyhow::anyhow!("Invalid CLI option"))
+        }
+    }
+}
+
+/// Handle CLI options for the application.
+pub fn handle_cli_options(args: Vec<String>) -> Result<()> {
+    let cli_option = args[1].as_str().parse::<CliOption>()?;
+
+    match cli_option {
+        CliOption::GenerateTokenEncryptionKey => {
+            let encryption_keys = fediproto_sync_lib::crypto::generate_token_encryption_key()?;
+
+            println!("{}", encryption_keys);
+
+            std::process::exit(0);
+        }
+    };
+}


### PR DESCRIPTION
## Description

This adds the ability to generate the token encryption keys directly through `fediproto-sync`. It can be done by running the following in a terminal:

```bash
fediproto-sync generate-token-encryption-keys
```

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#45 :point\_left:
