### PR TITLE
Add image resizing during compression

### DIFF
--- a/fediproto-sync/src/img_utils.rs
+++ b/fediproto-sync/src/img_utils.rs
@@ -1,9 +1,11 @@
 use std::io::Cursor;
 
 use fediproto_sync_lib::error::FediProtoSyncError;
-use image::{codecs::jpeg::JpegEncoder, ImageReader};
+use image::{codecs::jpeg::JpegEncoder, DynamicImage, GenericImageView, ImageReader};
 
 use crate::bsky::MAX_IMAGE_SIZE;
+
+const MAX_IMAGE_WIDTH: u32 = 1080;
 
 /// Compress an image using the JPEG format.
 ///
@@ -19,7 +21,24 @@ pub fn compress_image_from_bytes(image: &[u8]) -> Result<bytes::Bytes, FediProto
         .decode()
         .map_err(|_| FediProtoSyncError::ImageCompressionError)?;
 
-    let image_reader = image_reader.into_rgb8();
+    let image_dimensions = image_reader.dimensions();
+
+    // Resize the image if it's height is greater than `1080`.
+    let image_reader = match image_dimensions.1 > MAX_IMAGE_WIDTH {
+        true => {
+            let new_height = MAX_IMAGE_WIDTH;
+            let new_width = image_dimensions.0 * (new_height / image_dimensions.1);
+            
+            image::imageops::resize::<DynamicImage>(
+                &image_reader,
+                new_width,
+                new_height,
+                image::imageops::FilterType::Lanczos3
+            )
+        },
+
+        false => image_reader.into_rgba8()
+    };
 
     let mut image_buffer = vec![];
     let mut jpeg_encoder = JpegEncoder::new_with_quality(&mut image_buffer, 75);


### PR DESCRIPTION
## Description

If the image is being compressed and it's height is greater than `1080`, the image will be resized down to a height of `1080` before compression.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#48 :point\_left:
