### PR TITLE
Fix invalid URL for link embeds

### DIFF
--- a/fediproto-sync/src/bsky/rich_text.rs
+++ b/fediproto-sync/src/bsky/rich_text.rs
@@ -228,7 +228,7 @@ impl BlueSkyPostSyncRichText for BlueSkyPostSync<'_> {
                 app::bsky::embed::external::Main {
                     data: app::bsky::embed::external::MainData {
                         external: app::bsky::embed::external::ExternalData {
-                            uri: link_metadata["url"].as_str().unwrap().to_string(),
+                            uri: url.to_string(),
                             title: link_metadata["title"].as_str().unwrap().to_string(),
                             description: link_metadata["description"].as_str().unwrap().to_string(),
                             thumb: blob_item


### PR DESCRIPTION
## Description

Fixes an error where the URL metadata fetched by BlueSky's `cardyb` service is just a path. It just uses the URL passed through to the function for the embed.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#49 :point\_left:
