### PR TITLE
Remove snmalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,15 +513,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,7 +965,6 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_json",
- "snmalloc-rs",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3198,24 +3188,6 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "snmalloc-rs"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43ff92911d7d9705d1c0203300a3edfd00d16c8b8b0c27c56f9407a3f31e7a6"
-dependencies = [
- "snmalloc-sys",
-]
-
-[[package]]
-name = "snmalloc-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954e1f984860770475196be81a547ed1517d34fcb8a15cb87bdb37cff3353230"
-dependencies = [
- "cmake",
-]
 
 [[package]]
 name = "socket2"

--- a/fediproto-sync/Cargo.toml
+++ b/fediproto-sync/Cargo.toml
@@ -43,7 +43,6 @@ reqwest = { version = "0.12.12", features = [
 ], default-features = false }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"
-snmalloc-rs = { version = "0.3.7", features = ["lto"] }
 tokio = { version = "1.42.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/fediproto-sync/src/main.rs
+++ b/fediproto-sync/src/main.rs
@@ -15,9 +15,6 @@ use fediproto_sync_lib::{
     config::{FediProtoSyncConfig, FediProtoSyncMode}
 };
 
-#[global_allocator]
-static ALLOC: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
-
 /// The main entrypoint for the FediProtoSync application.
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
## Description

Removes `snmalloc` as the global allocator. It *reduces* memory usage, but it's minimal in our case and it might just be better to use the target system's memory allocator.

Typically what happens, memory wise, it'll start off using a minimal amount of memory (Usually less than `10MB`). Once an image that requires compression comes through, more memory will be allocated. Without `snmalloc`... I've typically seen it jump up pretty high (Over `70MB`), but once the image is compressed it drops down to between `30MB` and `40MB`. It pretty much stabilizes at that point, but any future image that requires compression will make it bump up *slightly*.

### Related issues

- None

### Stack

<!-- branch-stack -->

- `main`
  - \#57 :point\_left:
