### PR TITLE
Add jemalloc as global allocator for Linux

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -100,7 +100,8 @@
         "cwd": "${workspaceFolder}",
         "env": {
           "FEDIPROTO_SYNC_ENVIRONMENT": "Development_${input:dbType}",
-          "RUST_BACKTRACE": "1"
+          "RUST_BACKTRACE": "1",
+          "JEMALLOC_SYS_WITH_MALLOC_CONF": "background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,abort_conf:true"
         }
       },
       "presentation": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3421,6 +3422,26 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -324,6 +324,7 @@ workspace = false
 
 env.FEDIPROTOSYNC_INCLUDE_COMMIT_HASH = "true"
 env.FEDIPROTOSYNC_UPDATE_MANIFEST_VERSION = "true"
+env.JEMALLOC_SYS_WITH_MALLOC_CONF = "background_thread:true,narenas:1,lg_tcache_max:13,dirty_decay_ms:1000,abort_conf:true"
 env.PKG_CONFIG_SYSROOT_DIR = "/"
 dependencies = [
     "set-build-container-env-amd64",

--- a/fediproto-sync/Cargo.toml
+++ b/fediproto-sync/Cargo.toml
@@ -47,6 +47,9 @@ tokio = { version = "1.42.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6.0" }
+
 [build-dependencies]
 fediproto-sync-build-macros = { path = "../fediproto-sync-build-macros" }
 

--- a/fediproto-sync/Cargo.toml
+++ b/fediproto-sync/Cargo.toml
@@ -47,7 +47,7 @@ tokio = { version = "1.42.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(all(target_family = "unix", not(target_os = "macos")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }
 
 [build-dependencies]

--- a/fediproto-sync/src/main.rs
+++ b/fediproto-sync/src/main.rs
@@ -15,6 +15,10 @@ use fediproto_sync_lib::{
     config::{FediProtoSyncConfig, FediProtoSyncMode}
 };
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 /// The main entrypoint for the FediProtoSync application.
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/fediproto-sync/src/main.rs
+++ b/fediproto-sync/src/main.rs
@@ -15,7 +15,8 @@ use fediproto_sync_lib::{
     config::{FediProtoSyncConfig, FediProtoSyncMode}
 };
 
-#[cfg(not(target_env = "msvc"))]
+// Use Jemalloc for *nix-based systems, excluding macOS.
+#[cfg(all(target_family = "unix", not(target_os = "macos")))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
## Description

`jemalloc` is now the global allocator for Linux. Memory utilization is much better, especially in the context of a container. I *would* enable it for macOS, but there are some issues when it comes to compiling for `arm64` and linking to C libraries.

### Related issues

- None

### Stack

- `main` <!-- branch-stack -->
  - \#63 :point\_left:
