### PR TITLE
Revert back to oauth2 v4.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
  "fediproto-sync-build-macros",
  "fediproto-sync-db",
  "fediproto-sync-lib",
- "oauth2 5.0.0",
+ "oauth2",
  "serde",
  "tokio",
  "tracing",
@@ -1935,7 +1935,7 @@ dependencies = [
  "chrono",
  "futures-util",
  "hex",
- "oauth2 4.4.2",
+ "oauth2",
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.12",
@@ -2161,26 +2161,6 @@ dependencies = [
  "http 0.2.12",
  "rand 0.8.5",
  "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "url",
-]
-
-[[package]]
-name = "oauth2"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
-dependencies = [
- "base64 0.22.1",
- "chrono",
- "getrandom 0.2.15",
- "http 1.2.0",
- "rand 0.8.5",
- "reqwest 0.12.12",
  "serde",
  "serde_json",
  "serde_path_to_error",

--- a/fediproto-sync-auth-ui/Cargo.toml
+++ b/fediproto-sync-auth-ui/Cargo.toml
@@ -27,7 +27,7 @@ diesel = { version = "2.2.7", features = [
 ] }
 fediproto-sync-db = { path = "../fediproto-sync-db" }
 fediproto-sync-lib = { path = "../fediproto-sync-lib" }
-oauth2 = "5.0.0"
+oauth2 = "4.4.2"
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.42.0", features = ["full"] }
 tracing = "0.1.41"


### PR DESCRIPTION
## Description

Reverting `oauth2` back to `v4.4.2`. While implementing the breaking changes for `v5.0.0`, it broke the `megalodon` crate since it's still on `v4.4.2`. Once `megalodon` is updated, I can upgrade.

### Related issues

- None

### Stack

- `main` <!-- branch-stack -->
  - \#79 :point\_left:
