### PR TITLE
Revamp Mastodon client initialization

### DIFF
--- a/fediproto-sync-lib/src/error.rs
+++ b/fediproto-sync-lib/src/error.rs
@@ -16,6 +16,10 @@ pub enum FediProtoSyncError {
     #[error("Failed to authenticate to {0}.")]
     AuthenticationError(AuthenticationSource),
 
+    /// A DB connection pool error occurred.
+    #[error("DB connection pool error.")]
+    DatabaseConnectionPoolError,
+
     /// An invalid database type was specified.
     #[error("Invalid database type.")]
     InvalidDatabaseType,

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -23,7 +23,7 @@ pub struct FediProtoSyncLoop {
     /// The environment variables for the FediProto Sync application.
     config: FediProtoSyncConfig,
 
-    /// The database connection for the FediProto Sync application.
+    /// The database connection pool for the FediProto Sync application.
     db_connection_pool: Pool<ConnectionManager<AnyConnection>>,
 
     /// The ATProto agent for the FediProto Sync application.
@@ -387,6 +387,12 @@ pub fn create_atp_service_client(
     Ok(service_client)
 }
 
+/// Create a Mastodon client with `Megalodon`.
+/// 
+/// ## Arguments
+/// 
+/// * `config` - The environment variables for the FediProto Sync application.
+/// * `db_connection_pool` - The database connection pool for the FediProto Sync application.
 async fn create_mastodon_client(
     config: &FediProtoSyncConfig,
     db_connection_pool: &Pool<ConnectionManager<AnyConnection>>

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -60,7 +60,7 @@ impl FediProtoSyncLoop {
         let pds_service_endpoint = atproto_auth_data.1.replace("https://", "");
         let did = atproto_auth_data.2;
 
-        let mastodon_client = init_mastodon_client(&config, &db_connection_pool).await?;
+        let mastodon_client = create_mastodon_client(&config, &db_connection_pool).await?;
 
         let mastodon_account = mastodon_client
         .verify_account_credentials()
@@ -387,7 +387,7 @@ pub fn create_atp_service_client(
     Ok(service_client)
 }
 
-async fn init_mastodon_client(
+async fn create_mastodon_client(
     config: &FediProtoSyncConfig,
     db_connection_pool: &Pool<ConnectionManager<AnyConnection>>
 ) -> Result<Box<dyn Megalodon + Send + Sync>, FediProtoSyncError> {

--- a/fediproto-sync/src/core.rs
+++ b/fediproto-sync/src/core.rs
@@ -14,6 +14,7 @@ use fediproto_sync_lib::{
     config::FediProtoSyncConfig,
     error::{AuthenticationSource, FediProtoSyncError}
 };
+use megalodon::{entities::Account, Megalodon};
 
 use crate::{bsky, mastodon::MastodonApiExtensions};
 
@@ -23,13 +24,19 @@ pub struct FediProtoSyncLoop {
     config: FediProtoSyncConfig,
 
     /// The database connection for the FediProto Sync application.
-    db_connection: Pool<ConnectionManager<AnyConnection>>,
+    db_connection_pool: Pool<ConnectionManager<AnyConnection>>,
 
     /// The ATProto agent for the FediProto Sync application.
     atp_agent: AtpAgent<MemorySessionStore, ReqwestClient>,
 
     /// The DID for the authenticated ATProto session.
     did: Did,
+
+    /// The Mastodon client for the FediProto Sync application.
+    mastodon_client: Box<dyn Megalodon + Send + Sync>,
+
+    /// The account authenticated for the Mastodon client.
+    mastodon_account: Account,
 
     /// The PDS service endpoint for the authenticated ATProto session.
     pds_service_endpoint: String
@@ -44,21 +51,32 @@ impl FediProtoSyncLoop {
     ///   application.
     pub async fn new(
         config: &FediProtoSyncConfig,
-        db_connection: Pool<ConnectionManager<AnyConnection>>
+        db_connection_pool: Pool<ConnectionManager<AnyConnection>>
     ) -> Result<Self, FediProtoSyncError> {
         let config = config.clone();
 
         let atproto_auth_data = create_atp_agent(&config).await?;
-
         let atp_agent = atproto_auth_data.0;
         let pds_service_endpoint = atproto_auth_data.1.replace("https://", "");
         let did = atproto_auth_data.2;
 
+        let mastodon_client = init_mastodon_client(&config, &db_connection_pool).await?;
+
+        let mastodon_account = mastodon_client
+        .verify_account_credentials()
+        .await
+        .map_err(|_| FediProtoSyncError::AuthenticationError(AuthenticationSource::Mastodon))?
+        .json;
+
+        tracing::info!("Authenticated to Mastodon as '{}'", mastodon_account.username);
+
         Ok(Self {
             config,
-            db_connection,
+            db_connection_pool,
             atp_agent,
             did,
+            mastodon_client,
+            mastodon_account,
             pds_service_endpoint
         })
     }
@@ -102,41 +120,7 @@ impl FediProtoSyncLoop {
     ///   application.
     /// * `db_connection` - The database connection to use for the sync.
     async fn start_sync(&mut self) -> Result<()> {
-        let db_connection = &mut self.db_connection.get()?;
-
-        let cached_mastodon_token =
-            fediproto_sync_db::operations::get_cached_service_token_by_service_name(
-                db_connection,
-                "mastodon"
-            )?;
-
-        let cached_mastodon_token = match cached_mastodon_token {
-            Some(token) => token,
-            None => {
-                return Err(FediProtoSyncError::AuthenticationError(
-                    AuthenticationSource::Mastodon
-                )
-                .into());
-            }
-        };
-
-        let decrypted_mastodon_token = cached_mastodon_token
-            .decrypt_access_token(&self.config.token_encryption_private_key)?;
-
-        // Create the Mastodon client and authenticate.
-        let mastodon_client = megalodon::generator(
-            megalodon::SNS::Mastodon,
-            format!("https://{}", self.config.mastodon_server.clone()),
-            Some(decrypted_mastodon_token),
-            Some(self.config.user_agent.clone())
-        )
-        .map_err(|_| FediProtoSyncError::AuthenticationError(AuthenticationSource::Mastodon))?;
-
-        let account = mastodon_client
-            .verify_account_credentials()
-            .await
-            .map_err(|_| FediProtoSyncError::AuthenticationError(AuthenticationSource::Mastodon))?;
-        tracing::info!("Authenticated to Mastodon as '{}'", account.json.username);
+        let db_connection = &mut self.db_connection_pool.get()?;
 
         // Get the last synced post ID, if any.
         tracing::info!("Getting last synced post...");
@@ -147,8 +131,8 @@ impl FediProtoSyncLoop {
         // If there is no last synced post ID, we will only get the latest post.
         // Otherwise, we will get all posts since the last synced post.
         tracing::info!("Getting latest posts from Mastodon...");
-        let mut latest_posts = mastodon_client
-            .get_latest_posts(&account.json.id, last_synced_post_id.clone(), self.config.mastodon_allow_unlisted_posts)
+        let mut latest_posts = self.mastodon_client
+            .get_latest_posts(&self.mastodon_account.id, last_synced_post_id.clone(), self.config.mastodon_allow_unlisted_posts)
             .await?;
 
         // Reverse the posts so we process them in ascending order.
@@ -205,20 +189,20 @@ impl FediProtoSyncLoop {
             );
 
             for retry_item in posts_to_retry {
-                let fetched_post = mastodon_client.get_status(retry_item.id.to_string()).await;
+                let fetched_post = &self.mastodon_client.get_status(retry_item.id.to_string()).await;
 
                 match fetched_post {
                     Ok(post) => {
                         tracing::info!("Retrying sync for post '{}'", retry_item.id);
-                        let post = post.json;
+                        let post = &post.json;
 
                         let mut post_sync = bsky::BlueSkyPostSync {
                             config: self.config.clone(),
-                            db_connection_pool: self.db_connection.clone(),
+                            db_connection_pool: self.db_connection_pool.clone(),
                             atp_agent: &self.atp_agent,
                             pds_service_endpoint: self.pds_service_endpoint.clone(),
                             did: self.did.clone(),
-                            mastodon_account: account.json.clone(),
+                            mastodon_account: self.mastodon_account.clone(),
                             mastodon_status: post.clone(),
                             post_item: atrium_api::app::bsky::feed::post::RecordData {
                                 created_at: Datetime::now(),
@@ -284,11 +268,11 @@ impl FediProtoSyncLoop {
 
             let mut post_sync = bsky::BlueSkyPostSync {
                 config: self.config.clone(),
-                db_connection_pool: self.db_connection.clone(),
+                db_connection_pool: self.db_connection_pool.clone(),
                 atp_agent: &self.atp_agent,
                 pds_service_endpoint: self.pds_service_endpoint.clone(),
                 did: self.did.clone(),
-                mastodon_account: account.json.clone(),
+                mastodon_account: self.mastodon_account.clone(),
                 mastodon_status: post_item.clone(),
                 post_item: atrium_api::app::bsky::feed::post::RecordData {
                     created_at: Datetime::now(),
@@ -401,6 +385,45 @@ pub fn create_atp_service_client(
     let service_client = AtpServiceClient::new(client);
 
     Ok(service_client)
+}
+
+async fn init_mastodon_client(
+    config: &FediProtoSyncConfig,
+    db_connection_pool: &Pool<ConnectionManager<AnyConnection>>
+) -> Result<Box<dyn Megalodon + Send + Sync>, FediProtoSyncError> {
+    let db_connection = &mut db_connection_pool.get()
+        .map_err(|_| FediProtoSyncError::DatabaseConnectionPoolError)?;
+
+    let cached_mastodon_token =
+        fediproto_sync_db::operations::get_cached_service_token_by_service_name(
+            db_connection,
+            "mastodon"
+        )
+        .map_err(|_| FediProtoSyncError::AuthenticationError(AuthenticationSource::Mastodon))?;
+
+    let cached_mastodon_token = match cached_mastodon_token {
+        Some(token) => token,
+        None => {
+            return Err(FediProtoSyncError::AuthenticationError(
+                AuthenticationSource::Mastodon
+            )
+            .into());
+        }
+    };
+
+    let decrypted_mastodon_token = cached_mastodon_token
+        .decrypt_access_token(&config.token_encryption_private_key)?;
+
+    // Create the Mastodon client and authenticate.
+    let mastodon_client = megalodon::generator(
+        megalodon::SNS::Mastodon,
+        format!("https://{}", config.mastodon_server.clone()),
+        Some(decrypted_mastodon_token),
+        Some(config.user_agent.clone())
+    )
+    .map_err(|_| FediProtoSyncError::AuthenticationError(AuthenticationSource::Mastodon))?;
+
+    Ok(mastodon_client)
 }
 
 /// Create a new HTTP client for the FediProto Sync application.


### PR DESCRIPTION
## Description

Changes Mastodon client initialization from being done on every sync to just once during startup.

### Related issues

- None

### Stack

- `main` <!-- branch-stack -->
  - \#80 :point\_left:
