### PR TITLE
Use snmalloc for macOS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,6 +513,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +973,7 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_json",
+ "snmalloc-rs",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -3306,6 +3316,24 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "snmalloc-rs"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb317153089fdfa4d8a2eec059d40a5a23c3bde43995ea23b19121c3f621e74a"
+dependencies = [
+ "snmalloc-sys",
+]
+
+[[package]]
+name = "snmalloc-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065fea53d32bb77bc36cca466cb191f2e5216ebfd0ed360b1d64889ee6e559ea"
+dependencies = [
+ "cmake",
+]
 
 [[package]]
 name = "socket2"

--- a/fediproto-sync/Cargo.toml
+++ b/fediproto-sync/Cargo.toml
@@ -49,6 +49,9 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 [target.'cfg(all(target_family = "unix", not(target_os = "macos")))'.dependencies]
 tikv-jemallocator = { version = "0.6.0" }
 
+[target.'cfg(all(target_family = "unix", target_os = "macos"))'.dependencies]
+snmalloc-rs = { version = "0.3.8" }
+
 [build-dependencies]
 fediproto-sync-build-macros = { path = "../fediproto-sync-build-macros" }
 

--- a/fediproto-sync/src/main.rs
+++ b/fediproto-sync/src/main.rs
@@ -20,6 +20,11 @@ use fediproto_sync_lib::{
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
+// Use snmalloc for macOS-based systems.
+#[cfg(all(target_family = "unix", target_os = "macos"))]
+#[global_allocator]
+static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
+
 /// The main entrypoint for the FediProtoSync application.
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
## Description

Uses `snmalloc` as the global allocator for macOS builds.

### Related issues

- None

### Stack

- `main` <!-- branch-stack -->
  - \#89 :point\_left:
