### PR TITLE
Bump to Rust 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ package.homepage = "https://github.com/Smalls1652/fediproto-sync"
 package.repository = "https://github.com/Smalls1652/fediproto-sync"
 package.license = "MIT"
 package.license-file = "LICENSE"
-package.edition = "2021"
+package.edition = "2024"
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
## Description

Bumps the Rust edition to 2024.

### Related issues

- None

### Stack

- `main` <!-- branch-stack -->
  - \#97 :point\_left:
