### PR TITLE
Fix default DatabaseType value

### DIFF
--- a/fediproto-sync-lib/src/config.rs
+++ b/fediproto-sync-lib/src/config.rs
@@ -198,7 +198,7 @@ impl FediProtoSyncConfig {
         };
 
         // Read 'DATABASE_TYPE' environment variable.
-        let database_type = get_env_var!(DATABASE_TYPE_ENV_VAR, "postgres", DatabaseType)?;
+        let database_type = get_env_var!(DATABASE_TYPE_ENV_VAR, "Postgres", DatabaseType)?;
 
         // Read 'DATABASE_URL' environment variable.
         let database_url = get_env_var!(DATABASE_URL_ENV_VAR)?;


### PR DESCRIPTION
## Description

Fixes the default value if the `DATABASE_TYPE` environment value isn't provided. The value is case-sensitive, which I should fix in the future.

### Related issues

- None

### Stack

- `main` <!-- branch-stack -->
  - \#100 :point\_left:
